### PR TITLE
refactor!(buildData): change build return

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,15 +12,16 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v2
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile
@@ -32,13 +33,13 @@ jobs:
         working-directory: packages/dressed
         run: |
           if ${{ github.event.release.prerelease }}; then
-            bun publish --tag rc
+            bunx npm publish --provenance --tag rc
           else
-            bun publish
+            bunx npm publish --provenance --tag latest
           fi
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to JSR
         working-directory: packages/dressed
-        run: deno publish
+        run: bunx jsr publish

--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1"
   },
-  "packageManager": "bun@1.2.12"
+  "packageManager": "bun@1.2.13"
 }

--- a/packages/dressed/README.md
+++ b/packages/dressed/README.md
@@ -19,10 +19,11 @@ You can find an example of some bots ready to deploy on
 [Vercel](https://vercel.com) and [Deno deploy](https://deno.com/deploy) in
 [this repo](https://github.com/Inbestigator/dressed-examples).
 
-## Installation
+## Usage
 
 ```bash
 bun add dressed
+# or
 deno add jsr:@dressed/dressed
 ```
 
@@ -47,9 +48,7 @@ You can then build and run the bot with this command
 ```bash
 bun dressed build -ir
 bun bot.gen.ts
-```
-
-```bash
+# or
 deno -A jsr:@dressed/cmd build -ir
 deno -A bot.gen.ts
 ```

--- a/packages/dressed/src/bot/commands.ts
+++ b/packages/dressed/src/bot/commands.ts
@@ -1,14 +1,19 @@
-import type { CommandData, CommandHandler } from "../types/config.ts";
+import type {
+  CommandConfig,
+  CommandData,
+  CommandHandler,
+} from "../types/config.ts";
 import ora from "ora";
 import { trackParts, type WalkEntry } from "../build.ts";
-import { stdout } from "node:process";
+import { cwd, stdout } from "node:process";
 import { installGlobalCommands } from "./utils.ts";
 import { botEnv } from "../env.ts";
+import { join } from "node:path";
 
 /**
  * Installs commands to the Discord API
  */
-export async function installCommands(commands: CommandData<"ext">[]) {
+export async function installCommands(commands: CommandData[]) {
   const registerLoader = ora({
     stream: stdout,
     text: "Registering commands",
@@ -18,7 +23,9 @@ export async function installCommands(commands: CommandData<"ext">[]) {
     botEnv.DISCORD_APP_ID,
     await Promise.all(
       commands.map(async (c) => {
-        const { config } = await c.import();
+        const { config } = (await import(join(cwd(), c.path))) as {
+          config?: CommandConfig;
+        };
         let contexts = [];
         contexts = config?.contexts
           ? config.contexts.reduce<number[]>((acc, c) => {
@@ -57,7 +64,7 @@ export async function installCommands(commands: CommandData<"ext">[]) {
  * Creates the command handler
  * @returns A function that runs a command
  */
-export function setupCommands(commands: CommandData<"ext">[]): CommandHandler {
+export function setupCommands(commands: CommandData[]): CommandHandler {
   return async function runCommand(interaction) {
     const handler = commands.find((c) => c.name === interaction.data.name);
 
@@ -72,7 +79,9 @@ export function setupCommands(commands: CommandData<"ext">[]): CommandHandler {
     }).start();
 
     try {
-      await Promise.resolve((await handler.import()).default(interaction));
+      await Promise.resolve(
+        (await import(join(cwd(), handler.path))).default(interaction),
+      );
       commandLoader.succeed();
     } catch (error) {
       commandLoader.fail();
@@ -81,7 +90,7 @@ export function setupCommands(commands: CommandData<"ext">[]): CommandHandler {
   };
 }
 
-export function parseCommands(commandFiles: WalkEntry[]): CommandData<"int">[] {
+export function parseCommands(commandFiles: WalkEntry[]): CommandData[] {
   if (commandFiles.length === 0) return [];
   const generatingLoader = ora({
     stream: stdout,
@@ -90,7 +99,7 @@ export function parseCommands(commandFiles: WalkEntry[]): CommandData<"int">[] {
   const { addRow, log } = trackParts(commandFiles.length, "Command");
 
   try {
-    const commandData: CommandData<"int">[] = [];
+    const commandData: CommandData[] = [];
 
     for (const file of commandFiles) {
       const command = {

--- a/packages/dressed/src/bot/commands.ts
+++ b/packages/dressed/src/bot/commands.ts
@@ -1,4 +1,4 @@
-import type { BuildCommand, Command, CommandHandler } from "../types/config.ts";
+import type { CommandData, CommandHandler } from "../types/config.ts";
 import ora from "ora";
 import { trackParts, type WalkEntry } from "../build.ts";
 import { stdout } from "node:process";
@@ -8,7 +8,7 @@ import { botEnv } from "../env.ts";
 /**
  * Installs commands to the Discord API
  */
-export async function installCommands(commands: Command[]) {
+export async function installCommands(commands: CommandData<"ext">[]) {
   const registerLoader = ora({
     stream: stdout,
     text: "Registering commands",
@@ -57,7 +57,7 @@ export async function installCommands(commands: Command[]) {
  * Creates the command handler
  * @returns A function that runs a command
  */
-export function setupCommands(commands: Command[]): CommandHandler {
+export function setupCommands(commands: CommandData<"ext">[]): CommandHandler {
   return async function runCommand(interaction) {
     const handler = commands.find((c) => c.name === interaction.data.name);
 
@@ -81,7 +81,8 @@ export function setupCommands(commands: Command[]): CommandHandler {
   };
 }
 
-export function parseCommands(commandFiles: WalkEntry[]) {
+export function parseCommands(commandFiles: WalkEntry[]): CommandData<"int">[] {
+  if (commandFiles.length === 0) return [];
   const generatingLoader = ora({
     stream: stdout,
     text: "Generating commands",
@@ -89,10 +90,10 @@ export function parseCommands(commandFiles: WalkEntry[]) {
   const { addRow, log } = trackParts(commandFiles.length, "Command");
 
   try {
-    const commandData: BuildCommand[] = [];
+    const commandData: CommandData<"int">[] = [];
 
     for (const file of commandFiles) {
-      const command: BuildCommand = {
+      const command = {
         name: file.name,
         path: file.path,
       };

--- a/packages/dressed/src/bot/components.ts
+++ b/packages/dressed/src/bot/components.ts
@@ -1,9 +1,5 @@
 import { basename, dirname } from "node:path";
-import type {
-  BuildComponent,
-  Component,
-  ComponentHandler,
-} from "../types/config.ts";
+import type { ComponentData, ComponentHandler } from "../types/config.ts";
 import { trackParts, type WalkEntry } from "../build.ts";
 import ora from "ora";
 import { stdout } from "node:process";
@@ -12,7 +8,9 @@ import { stdout } from "node:process";
  * Creates the component handler
  * @returns A function that runs a component
  */
-export function setupComponents(components: Component[]): ComponentHandler {
+export function setupComponents(
+  components: ComponentData<"ext">[],
+): ComponentHandler {
   return async function runComponent(interaction) {
     const category = getCategory();
 
@@ -85,7 +83,10 @@ export function parseArgs(str: string) {
 
 const validComponentCategories = ["buttons", "modals", "selects"];
 
-export function parseComponents(componentFiles: WalkEntry[]) {
+export function parseComponents(
+  componentFiles: WalkEntry[],
+): ComponentData<"int">[] {
+  if (componentFiles.length === 0) return [];
   const generatingLoader = ora({
     stream: stdout,
     text: "Generating components",
@@ -96,7 +97,7 @@ export function parseComponents(componentFiles: WalkEntry[]) {
     "Category",
   );
   try {
-    const componentData: BuildComponent[] = [];
+    const componentData: ComponentData<"int">[] = [];
 
     for (const file of componentFiles) {
       const category = basename(dirname(file.path));
@@ -108,9 +109,9 @@ export function parseComponents(componentFiles: WalkEntry[]) {
         continue;
       }
 
-      const component: BuildComponent = {
+      const component = {
         name: file.name,
-        category: category as BuildComponent["category"],
+        category,
         regex: parseArgs(file.name).source,
         path: file.path,
       };
@@ -128,7 +129,7 @@ export function parseComponents(componentFiles: WalkEntry[]) {
         continue;
       }
 
-      componentData.push(component);
+      componentData.push(component as ComponentData<"int">);
       addRow(component.name, category.slice(0, -1));
     }
 

--- a/packages/dressed/src/bot/events.ts
+++ b/packages/dressed/src/bot/events.ts
@@ -1,4 +1,4 @@
-import type { BuildEvent, Event, EventHandler } from "../types/config.ts";
+import type { EventData, EventHandler } from "../types/config.ts";
 import { trackParts, type WalkEntry } from "../build.ts";
 import ora from "ora";
 import { stdout } from "node:process";
@@ -8,7 +8,7 @@ import { ApplicationWebhookEventType } from "discord-api-types/v10";
  * Creates the event handler
  * @returns A function that runs an event
  */
-export function setupEvents(events: Event[]): EventHandler {
+export function setupEvents(events: EventData<"ext">[]): EventHandler {
   return async function runEvent(event) {
     const handler = events.find((c) => c.type === event.type);
 
@@ -38,14 +38,15 @@ export function setupEvents(events: Event[]): EventHandler {
   };
 }
 
-export function parseEvents(eventFiles: WalkEntry[]) {
+export function parseEvents(eventFiles: WalkEntry[]): EventData<"int">[] {
+  if (eventFiles.length === 0) return [];
   const generatingLoader = ora({
     stream: stdout,
     text: "Generating events",
   }).start();
   const { addRow, log } = trackParts(eventFiles.length, "Event");
   try {
-    const eventData: BuildEvent[] = [];
+    const eventData: EventData<"int">[] = [];
 
     for (const file of eventFiles) {
       const type =
@@ -60,7 +61,7 @@ export function parseEvents(eventFiles: WalkEntry[]) {
         continue;
       }
 
-      const event: BuildEvent = {
+      const event = {
         name: file.name,
         type,
         path: file.path,

--- a/packages/dressed/src/server/index.ts
+++ b/packages/dressed/src/server/index.ts
@@ -19,7 +19,12 @@
  */
 
 // Types
-export type { ServerConfig } from "../types/config.ts";
+export type {
+  CommandData,
+  ComponentData,
+  EventData,
+  ServerConfig,
+} from "../types/config.ts";
 export type { CommandHandler, ComponentHandler } from "../types/config.ts";
 
 // Core

--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -5,7 +5,6 @@ import type {
 } from "./interaction.ts";
 import type {
   APIWebhookEventBody,
-  ApplicationWebhookEventType,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from "discord-api-types/v10";
 
@@ -37,54 +36,29 @@ export type CommandConfig = Omit<
 /**
  * Command data object in the `commandData` array outputted from `build()`
  */
-export type CommandData<T extends "int" | "ext"> = T extends "int"
-  ? {
-      name: string;
-      path: string;
-    }
-  : {
-      name: string;
-      import: () => Promise<{
-        config?: CommandConfig;
-        default: CommandHandler;
-      }>;
-    };
+export type CommandData = {
+  name: string;
+  path: string;
+};
 
 /**
  * Component data object in the `componentData` array outputted from `build()`
  */
-export type ComponentData<T extends "int" | "ext"> = T extends "int"
-  ? {
-      name: string;
-      regex: string;
-      category: "buttons" | "modals" | "selects";
-      path: string;
-    }
-  : {
-      name: string;
-      regex: string;
-      category: string;
-      import: () => Promise<{
-        default: unknown;
-      }>;
-    };
+export type ComponentData = {
+  name: string;
+  regex: string;
+  category: string;
+  path: string;
+};
 
 /**
  * Event data object in the `eventData` array outputted from `build()`
  */
-export type EventData<T extends "int" | "ext"> = T extends "int"
-  ? {
-      name: string;
-      type: ApplicationWebhookEventType;
-      path: string;
-    }
-  : {
-      name: string;
-      type: string;
-      import: () => Promise<{
-        default: unknown;
-      }>;
-    };
+export type EventData = {
+  name: string;
+  type: string;
+  path: string;
+};
 
 export type CommandHandler = (interaction: CommandInteraction) => Promise<void>;
 export type ComponentHandler = (

--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -33,48 +33,58 @@ export type CommandConfig = Omit<
   /** Where a command can be installed, also called its supported installation context. Defaults to both */
   integration_type?: "Guild" | "User";
 };
-export interface Command {
-  name: string;
-  import: () => Promise<{
-    config?: CommandConfig;
-    default: CommandHandler;
-  }>;
-}
 
-export interface BuildCommand {
-  name: string;
-  path: string;
-}
+/**
+ * Command data object in the `commandData` array outputted from `build()`
+ */
+export type CommandData<T extends "int" | "ext"> = T extends "int"
+  ? {
+      name: string;
+      path: string;
+    }
+  : {
+      name: string;
+      import: () => Promise<{
+        config?: CommandConfig;
+        default: CommandHandler;
+      }>;
+    };
 
-export interface Component {
-  name: string;
-  regex: string;
-  category: string;
-  import: () => Promise<{
-    default: unknown;
-  }>;
-}
+/**
+ * Component data object in the `componentData` array outputted from `build()`
+ */
+export type ComponentData<T extends "int" | "ext"> = T extends "int"
+  ? {
+      name: string;
+      regex: string;
+      category: "buttons" | "modals" | "selects";
+      path: string;
+    }
+  : {
+      name: string;
+      regex: string;
+      category: string;
+      import: () => Promise<{
+        default: unknown;
+      }>;
+    };
 
-export interface BuildComponent {
-  name: string;
-  regex: string;
-  category: "buttons" | "modals" | "selects";
-  path: string;
-}
-
-export interface Event {
-  name: string;
-  type: string;
-  import: () => Promise<{
-    default: unknown;
-  }>;
-}
-
-export interface BuildEvent {
-  name: string;
-  type: ApplicationWebhookEventType;
-  path: string;
-}
+/**
+ * Event data object in the `eventData` array outputted from `build()`
+ */
+export type EventData<T extends "int" | "ext"> = T extends "int"
+  ? {
+      name: string;
+      type: ApplicationWebhookEventType;
+      path: string;
+    }
+  : {
+      name: string;
+      type: string;
+      import: () => Promise<{
+        default: unknown;
+      }>;
+    };
 
 export type CommandHandler = (interaction: CommandInteraction) => Promise<void>;
 export type ComponentHandler = (

--- a/packages/dressed/tests/build.test.ts
+++ b/packages/dressed/tests/build.test.ts
@@ -1,39 +1,39 @@
 import { expect, test } from "bun:test";
 import { build, ServerConfig } from "../src/server";
 
-const withoutBoth = `export const commandData = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const componentData = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const eventData = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
+const withoutBoth = `export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
+export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
+export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
 export const config = {"root":"tests/src"};`;
 
 const withInstance = `import { createServer, setupCommands, setupComponents, setupEvents } from "dressed/server";
 
-export const commandData = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const componentData = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const eventData = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
+export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
+export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
+export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
 export const config = {"root":"tests/src"};
 
-createServer(setupCommands(commandData), setupComponents(componentData), setupEvents(eventData), config);`;
+createServer(setupCommands(commands), setupComponents(components), setupEvents(events), config);`;
 
 const withRegister = `import { installCommands } from "dressed/server";
 
-export const commandData = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const componentData = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const eventData = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
+export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
+export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
+export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
 export const config = {"root":"tests/src"};
 
-installCommands(commandData);`;
+installCommands(commands);`;
 
 const withBoth = `import { createServer, installCommands, setupCommands, setupComponents, setupEvents } from "dressed/server";
 
-export const commandData = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const componentData = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const eventData = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
+export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
+export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
+export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
 export const config = {"root":"tests/src"};
 
-installCommands(commandData);
+installCommands(commands);
 
-createServer(setupCommands(commandData), setupComponents(componentData), setupEvents(eventData), config);`;
+createServer(setupCommands(commands), setupComponents(components), setupEvents(events), config);`;
 
 const config: ServerConfig = { root: "tests/src" };
 

--- a/packages/dressed/tests/build.test.ts
+++ b/packages/dressed/tests/build.test.ts
@@ -1,58 +1,27 @@
 import { expect, test } from "bun:test";
 import { build, ServerConfig } from "../src/server";
 
-const withoutBoth = `export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
-export const config = {"root":"tests/src"};`;
-
-const withInstance = `import { createServer, setupCommands, setupComponents, setupEvents } from "dressed/server";
-
-export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
-export const config = {"root":"tests/src"};
-
-createServer(setupCommands(commands), setupComponents(components), setupEvents(events), config);`;
-
-const withRegister = `import { installCommands } from "dressed/server";
-
-export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
-export const config = {"root":"tests/src"};
-
-installCommands(commands);`;
-
-const withBoth = `import { createServer, installCommands, setupCommands, setupComponents, setupEvents } from "dressed/server";
-
-export const commands = [{"name":"ping","import": ()=>import("./tests/src/commands/ping.ts")}];
-export const components = [{"name":"button_[arg]","category":"buttons","regex":"^button_(?<arg>.+)$","import": ()=>import("./tests/src/components/buttons/button_[arg].ts")}];
-export const events = [{"name":"ApplicationAuthorized","type":"APPLICATION_AUTHORIZED","import": ()=>import("./tests/src/events/ApplicationAuthorized.ts")}];
-export const config = {"root":"tests/src"};
-
-installCommands(commands);
-
-createServer(setupCommands(commands), setupComponents(components), setupEvents(events), config);`;
-
 const config: ServerConfig = { root: "tests/src" };
 
-test("Build bot without instance or register", async () => {
-  const result = await build(false, false, config);
-  expect(result).toBe(withoutBoth);
-});
-
-test("Build bot with instance", async () => {
-  const result = await build(true, false, config);
-  expect(result).toBe(withInstance);
-});
-
-test("Build bot with register", async () => {
-  const result = await build(false, true, config);
-  expect(result).toBe(withRegister);
-});
-
-test("Build bot with instance and register", async () => {
-  const result = await build(true, true, config);
-  expect(result).toBe(withBoth);
+test("Build bot", async () => {
+  const result = await build(config);
+  expect(result).toEqual({
+    commands: [{ name: "ping", path: "tests/src/commands/ping.ts" }],
+    components: [
+      {
+        name: "button_[arg]",
+        category: "buttons",
+        regex: "^button_(?<arg>.+)$",
+        path: "tests/src/components/buttons/button_[arg].ts",
+      },
+    ],
+    events: [
+      {
+        name: "ApplicationAuthorized",
+        type: "APPLICATION_AUTHORIZED",
+        path: "tests/src/events/ApplicationAuthorized.ts",
+      },
+    ],
+    config: { root: "tests/src" },
+  });
 });

--- a/packages/dressed/tests/src/commands/ping.ts
+++ b/packages/dressed/tests/src/commands/ping.ts
@@ -5,5 +5,6 @@ export const config: CommandConfig = {
 };
 
 export default async function (interaction: CommandInteraction) {
+  console.log("a");
   await interaction.reply("Pong!");
 }

--- a/packages/dressed/tsconfig.json
+++ b/packages/dressed/tsconfig.json
@@ -3,14 +3,15 @@
     "allowImportingTsExtensions": true,
     "declaration": true,
     "erasableSyntaxOnly": true,
-    "module": "nodenext",
+    "module": "NodeNext",
     "outDir": "dist",
     "rewriteRelativeImportExtensions": true,
     "rootDir": "src",
     "sourceMap": true,
-    // Why not ESNext? Because with ES2022 we know which version of runtime(s) we are supporting
-    "target": "ES2015",
-    "verbatimModuleSyntax": true
+    "target": "ES2018",
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "stripInternal": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Build function now returns:
```diff
- export const commandData = [...]
+ export const commands = [...]
- export const componentData = [...]
+ export const components = [...]
- export const eventData = [...]
+ export const events = [...]
```

Planning on changing the build function entirely so that it just returns the data instead of a string, then stuff like `dressed build` can use that to generate files.