### PR TITLE
refactor(dressed-matcher): improve speed and added custom matching

### DIFF
--- a/packages/dressed-matcher/README.md
+++ b/packages/dressed-matcher/README.md
@@ -4,16 +4,34 @@ A tiny utility for creating [regexes](https://en.wikipedia.org/wiki/Regular_expr
 
 ## 🧩 Pattern Syntax
 
-| Syntax     | Description                      |
-| ---------- | -------------------------------- |
-| `:argname` | Defines a named argument         |
-| `{...}`    | Marks content inside as optional |
-| And more!  | Easily plug in your own tokens   |
+| Syntax       | Description                      |
+| ------------ | -------------------------------- |
+| `:<argname>` | Defines a named argument         |
+| `{...}`      | Marks content inside as optional |
+| `(...)`      | Content inside is a custom regex |
+| And more!    | Easily plug in your own tokens   |
+
+You can pair arguments with custom regexes to make sure the argument value matches the regex.
+
+<details>
+<summary>Sample paired regex</summary>
+
+Input: `i-love-:animal(dogs|cats)`\
+Output: `/^i-love-(?\<animal>(?:dogs|cats))$/`\
+Will match:
+
+- `i-love-dogs`
+- `i-love-cats`
+
+</details>
 
 ### Examples:
 
 1. `button-:variant` matches `button-primary`, `button-secondary`, etc.
-2. `dialog{-:state}` matches `dialog`, `dialog-open`, `dialog-closed`, etc.
+2. `wait{-:length}` matches `wait`, `wait-100`, `wait-200`, etc.
+   - For better verboseness, you could use `wait{-:length(\d)}`
+3. `ticket-(open|close)` matches `ticket-open`, `ticket-close`
+4. `ticket-action:(open|close)` is the same as 3, except the action is captured
 
 ## 🧮 `matchOptimal()`
 

--- a/packages/dressed-matcher/package.json
+++ b/packages/dressed-matcher/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "dist": "rm -fr dist && bun tsc",
     "check-types": "bun tsc --noEmit",
+    "test": "bun test",
     "dry-publish": "bun publish --dry-run"
   },
   "type": "module",

--- a/packages/dressed-matcher/src/index.ts
+++ b/packages/dressed-matcher/src/index.ts
@@ -1,73 +1,146 @@
-type Token =
-  | { match: RegExp; replace: string }
-  | {
-      prefix: string;
-      match: RegExp;
-      handler: (str: string, pos: number) => string | null;
-    };
+type Token = {
+  prefix: string;
+  suffix?: string;
+  handler: (str: string, pos: number) => string | null;
+};
 
 const defaultTokens: Token[] = [
   {
-    match: /:([a-zA-Z0-9]+)/,
-    replace: "(?<$1>.+?)",
+    prefix: ":",
+    handler: (str, pos) => {
+      const nameMatch = /^[a-zA-Z0-9]+/.exec(str.slice(pos + 1));
+      if (!nameMatch) return null;
+
+      const name = nameMatch[0];
+      const next = pos + 1 + name.length;
+      let innerMatch = ".+?";
+
+      if (str[next] === "(") {
+        let depth = 1;
+        let i = next + 1;
+        while (i < str.length && depth > 0) {
+          if (str[i] === "(") depth++;
+          else if (str[i] === ")") depth--;
+          i++;
+        }
+        if (depth > 0) return null;
+
+        const inner = str.slice(next, i);
+        innerMatch = parsePattern(inner);
+      }
+
+      return `(?<${name}>${innerMatch})`;
+    },
   },
   {
     prefix: "{",
-    match: /^{(.+)}/,
+    suffix: "}",
     handler: (content) => {
       const innerParsed = parsePattern(content);
       return `(?:${innerParsed})?`;
     },
   },
+  {
+    prefix: "(",
+    suffix: ")",
+    handler: (content) => {
+      if (content.startsWith("?:")) return `(${content})`;
+      const innerParsed = parsePattern(content, { preservedOperators: true });
+      return `(?:${innerParsed})`;
+    },
+  },
 ];
 
 const escapeRegex = (str: string): string =>
-  str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  str.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&");
 
-function parsePattern<S extends boolean>(
+const patternCache: Record<string, string> = {};
+
+function parsePattern(
   pattern: string,
-  config?: { tokens?: Token[]; isScoring?: S },
-): S extends true ? number : string {
+  config?: { tokens?: Token[]; preservedOperators?: string[] | true },
+): string {
+  if (patternCache[pattern]) {
+    return patternCache[pattern];
+  }
   const tokens = config?.tokens ?? defaultTokens;
   let result = "";
   let i = 0;
-
-  const replacers = tokens.filter((t) => "replace" in t);
-  const handlers = tokens.filter((t) => "handler" in t);
 
   while (i < pattern.length) {
     let matched = false;
     const char = pattern[i];
 
-    for (const { handler, prefix, match } of handlers) {
+    for (const { handler, prefix, suffix } of tokens) {
       if (char !== prefix) continue;
-      const res = match.exec(pattern.slice(i));
-      if (!res || !res[1]) continue;
-      matched = true;
-      const replacement = handler(res[1], i);
-      if (!replacement) continue;
-      result += replacement;
-      i += replacement.length;
-      break;
+
+      if (!suffix) {
+        const replaced = handler(pattern, i);
+        if (replaced != null) {
+          result += replaced;
+
+          const nameMatch = /^[a-zA-Z0-9_]+/.exec(pattern.slice(i + 1));
+          if (!nameMatch) break;
+
+          const next = i + 1 + nameMatch[0].length;
+
+          if (pattern[next] === "(") {
+            let depth = 1;
+            let j = next + 1;
+            while (j < pattern.length && depth > 0) {
+              if (pattern[j] === "(") depth++;
+              else if (pattern[j] === ")") depth--;
+              j++;
+            }
+            i = j;
+          } else {
+            i = next;
+          }
+
+          matched = true;
+          break;
+        }
+      } else {
+        const end = (() => {
+          let depth = 1;
+          for (let j = i + 1; j < pattern.length; j++) {
+            if (pattern[j] === prefix) depth++;
+            else if (pattern[j] === suffix) depth--;
+            if (depth === 0) return j;
+          }
+          return -1;
+        })();
+
+        if (end === -1) continue;
+
+        const content = pattern.slice(i + 1, end);
+        const replaced = handler(content, i);
+
+        if (replaced != null) {
+          result += replaced;
+          i = end + 1;
+          matched = true;
+          break;
+        }
+      }
     }
 
     if (!matched) {
-      result += escapeRegex(char);
+      if (
+        config?.preservedOperators === true ||
+        config?.preservedOperators?.includes(char)
+      ) {
+        result += char;
+      } else {
+        result += escapeRegex(char);
+      }
       i++;
     }
   }
 
-  for (const replacer of replacers) {
-    result = result.replace(
-      new RegExp(replacer.match, `g${replacer.match.flags}`),
-      replacer.replace,
-    );
-  }
-  if (config?.isScoring) {
-    const rawLength = result.replace(/[^\\]?\(.+\)/g, "").length;
-    return (rawLength / result.length) as ReturnType<typeof parsePattern<S>>;
-  }
-  return result as ReturnType<typeof parsePattern<S>>;
+  patternCache[pattern] = result;
+
+  return result;
 }
 
 export const patternToRegex = (pattern: string): RegExp =>
@@ -75,7 +148,9 @@ export const patternToRegex = (pattern: string): RegExp =>
 
 /** Scores dynamic-ness, higher is less dynamic */
 export function scorePattern(pattern: string): number {
-  return parsePattern(pattern, { isScoring: true });
+  const regex = parsePattern(pattern);
+  const rawLength = regex.replace(/\(\?.+?\)/g, "").length;
+  return (rawLength * (regex.match(/\(\?/g)?.length ?? 1)) / regex.length;
 }
 
 export function matchOptimal(input: string, regexes: RegExp[]) {

--- a/packages/dressed-matcher/tests/index.test.ts
+++ b/packages/dressed-matcher/tests/index.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import { patternToRegex, scorePattern, matchOptimal } from "@dressed/matcher";
+
+test("patternToRegex: matches static", () => {
+  const regex = patternToRegex("static");
+  expect(regex.test("static")).toBe(true);
+  expect(regex.test("STATIC")).toBe(false);
+});
+
+test("patternToRegex: matches parameter", () => {
+  const regex = patternToRegex(":name");
+  const match = regex.exec("hello");
+  expect(match?.groups?.name).toBe("hello");
+});
+
+test("patternToRegex: matches parameter with custom regex", () => {
+  const regex = patternToRegex(":num(\\d+)");
+  expect(regex.test("123")).toBe(true);
+  expect(regex.test("abc")).toBe(false);
+});
+
+test("patternToRegex: handles optional tokens", () => {
+  const regex = patternToRegex("{:opt}");
+  expect(regex.test("")).toBe(true);
+  expect(regex.test("anything")).toBe(true);
+});
+
+test("scorePattern: score order plain > :n(\\d+) > {maybe} > :p", () => {
+  const scores = {
+    plain: scorePattern("plain"),
+    typed: scorePattern(":n(\\d+)"),
+    optional: scorePattern("{maybe}"),
+    param: scorePattern(":p"),
+  };
+
+  expect(scores.plain).toBe(1);
+  expect(scores.param).toBe(0);
+
+  expect(scores.plain).toBeGreaterThan(scores.typed);
+  expect(scores.typed).toBeGreaterThan(scores.optional);
+  expect(scores.optional).toBeGreaterThan(scores.param);
+});
+
+test("matchOptimal: chooses best match by order", () => {
+  const patterns = ["user-:id(\\d+)", "user-{opt}", ":username"];
+
+  const regexes = patterns.map(patternToRegex);
+
+  const result = matchOptimal("user-123", regexes);
+  expect(result.index).toBe(0);
+  expect(result.match?.groups?.id).toBe("123");
+
+  const result2 = matchOptimal("admin", regexes);
+  expect(result2.index).toBe(2);
+  expect(result2.match?.groups?.username).toBe("admin");
+});
+
+test("matchOptimal: returns -1 if no match", () => {
+  const regexes: RegExp[] = [patternToRegex("abc"), patternToRegex("def")];
+  const result = matchOptimal("zzz", regexes);
+  expect(result.index).toBe(-1);
+});


### PR DESCRIPTION
Added regex syntax allowed within `(...)`s

You can pair arguments with custom regexes to enforce stricter validations.

e.g. `i-love-:animal(dogs|cats)` -> `/^i-love-(?\<animal>(?:dogs|cats))$/`