### PR TITLE
fix(handlers): fallback to run if no exports

### DIFF
--- a/packages/dressed/src/server/handlers/index.ts
+++ b/packages/dressed/src/server/handlers/index.ts
@@ -44,8 +44,8 @@ export function createHandlerSetup<
 
       try {
         let handler: T["run"] | undefined;
-        if (key) {
-          handler = item.exports?.[key as keyof typeof item.exports];
+        if (key && item.exports) {
+          handler = item.exports[key as keyof typeof item.exports];
           if (!handler) {
             throw new Error(`Unable to find '${String(key)}' in exports`);
           }


### PR DESCRIPTION
Previously when using default server logic, if you're using run (deprecated) it'd never fall back to it