### PR TITLE
feat(commands): support guilds on installCommands

### DIFF
--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -4,6 +4,7 @@ import type {
   RESTPostAPIChatInputApplicationCommandsJSONBody,
   RESTPostAPIContextMenuApplicationCommandsJSONBody,
   RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody,
+  Snowflake,
 } from "discord-api-types/v10";
 import type { Promisable } from "./possible-promise.ts";
 import type {
@@ -76,6 +77,8 @@ type BaseCommandConfig = {
   contexts?: (keyof typeof InteractionContextType)[];
   /** Where a command can be installed, also called its supported installation context. Defaults to both */
   integration_type?: "Guild" | "User";
+  /** The guilds this command is available in, this prop will cause the command to become guild-scoped */
+  guilds?: Snowflake[];
 };
 
 type CommandTypeConfig<T, K extends PropertyKey, A> = Omit<


### PR DESCRIPTION
New `guilds` array prop on `CommandConfig`.

Setting guild ids in the array will cause the command to be registered only for those guilds instead of globally, an empty array will register the command nowhere.

When the array is added, the command will be unregistered from the global scope.

> [!IMPORTANT]
> When a guild is removed from the array, the command isn't unregistered, you will have to call the `bulkOverwriteGuildCommands` function on that guild to update it.

Resolves #119