### PR TITLE
fix(server): listen on all network interfaces instead of just 127.0.0.1

### DIFF
--- a/packages/dressed/src/server/server.ts
+++ b/packages/dressed/src/server/server.ts
@@ -73,7 +73,7 @@ export function createServer(
 
   const port = config.port ?? 8000;
 
-  server.listen(port, "localhost", () => {
+  server.listen(port, "0.0.0.0", () => {
     console.log(
       "Bot is now listening on",
       new URL(config.endpoint ?? "", `http://localhost:${port}`).href,


### PR DESCRIPTION
I found this when deploying dressed to a docker container (see here: https://github.com/HardCarryClub/bald-man-bot). Due to the server being created on `localhost` it's not listening to all network interfaces which *should* still maintain full compatibility while also allowing Docker to work.