### PR TITLE
docs: expand pattern export and add note for Windows users

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,9 @@
     "": {
       "name": "dressed",
       "devDependencies": {
-        "@eslint/js": "^9.31.0",
+        "@eslint/js": "^9.32.0",
         "@types/bun": "1.2.18",
-        "eslint": "^9.31.0",
+        "eslint": "^9.32.0",
         "globals": "^16.3.0",
         "prettier": "^3.6.2",
         "turbo": "^2.5.5",
@@ -80,6 +80,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
+        "rehype-callouts": "^2.1.2",
         "rehype-highlight": "^7.0.2",
         "rehype-pretty-code": "^0.14.1",
         "rehype-slug": "^6.0.0",
@@ -1214,6 +1215,8 @@
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "rehype-callouts": ["rehype-callouts@2.1.2", "", { "dependencies": { "@types/hast": "^3.0.4", "hast-util-from-html": "^2.0.3", "hast-util-is-element": "^3.0.0", "hastscript": "^9.0.1", "unist-util-visit": "^5.0.0" } }, "sha512-ZZWZ6EknUHiSzr4pQ88C7db3su4DElfJRmphZJbXpDdwW3urTwlYZpHckoC9pjEvBmUEEiJAM0uuc2uxyLdTfg=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
 

--- a/www/content/components.md
+++ b/www/content/components.md
@@ -42,6 +42,9 @@ export default async function guess(
 
 ## Dynamic Component IDs
 
+> [!IMPORTANT]
+> If you are are Windows or have Windows developers you will have issues with the file name method for dynamic component, you're recommended to use [Pattern Export](#pattern-export) over filenames.
+
 As you may have noticed in the previous example, a component can be passed certain arguments.
 
 Components can be **parameterized** using special patterns in their filenames. This enables you to match component IDs dynamically and extract arguments from them. Dynamic IDs can be applied to any component type.
@@ -54,10 +57,18 @@ You can also make parts of the pattern **optional** using `{...}`. This allows c
 
 If you'd like to add some regex syntax, you can simply do `(...)`. This can be paired with an argument to ensure the argument value is correct.
 
-Alternatively, if your pattern is too long/complex for a filename, you can export it instead.
+### Pattern Export
+If you have a complex dynamic ID or you're on Windows you may opt to use the `pattern` export over file name. Using pattern export will override file name completely.
 
+#### Before
+```sh
+/trivia_guess_:answer.ts
+```
+
+#### After
 ```ts
-export const pattern = "...";
+// trivia_guess_answer.ts
+export const pattern = "trivia_guess_:answer"; // Still responds to `trivia_guess_(.+)` no matter the filename
 ```
 
 ### Examples

--- a/www/package.json
+++ b/www/package.json
@@ -21,6 +21,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "rehype-callouts": "^2.1.2",
     "rehype-highlight": "^7.0.2",
     "rehype-pretty-code": "^0.14.1",
     "rehype-slug": "^6.0.0",

--- a/www/src/app/globals.css
+++ b/www/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
-
 @config "../../tailwind.config.ts";
+@import 'rehype-callouts/theme/github';
+
 @layer base {
   :root {
     --background: 240 9% 13%;
@@ -43,3 +44,4 @@
     @apply bg-background text-foreground;
   }
 }
+

--- a/www/src/components/docs-md.tsx
+++ b/www/src/components/docs-md.tsx
@@ -3,6 +3,7 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import rehypeUnwrapImages from "rehype-unwrap-images";
 import rehypePrettyCode from "rehype-pretty-code";
+import rehypeCallouts from "rehype-callouts";
 
 export default function DocsMD({ content }: { content: string }) {
   return (
@@ -12,6 +13,7 @@ export default function DocsMD({ content }: { content: string }) {
           [rehypePrettyCode, { theme: "catppuccin-mocha" }],
           rehypeSlug,
           rehypeUnwrapImages,
+          rehypeCallouts,
         ]}
         remarkPlugins={[remarkGfm]}
       >


### PR DESCRIPTION
Expanding on pattern export documentation. Here's what the changes look like:

<img width="1477" height="896" alt="image" src="https://github.com/user-attachments/assets/a209ade4-9a38-497a-8fb3-0f7dde59a14a" />

Added [`rehype-callouts`](https://github.com/lin-stephanie/rehype-callouts) as well

Closes #130