### PR TITLE
feat(dressed-react): labels and generic command types

### DIFF
--- a/packages/dressed-react/package.json
+++ b/packages/dressed-react/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@dressed/react",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Inbestigator/dressed.git",
     "directory": "packages/dressed-react"
   },
   "peerDependencies": {
-    "dressed": "^1.9.1",
+    "dressed": "^1.10.0",
     "react": "^19.1.1"
   },
   "exports": "./dist/index.js",

--- a/packages/dressed-react/src/components/label.ts
+++ b/packages/dressed-react/src/components/label.ts
@@ -1,0 +1,28 @@
+import { Label as DressedComponent } from "dressed";
+import { createElement, type ReactElement, type ReactNode } from "react";
+import type { APILabelComponent } from "discord-api-types/v10";
+import { renderNode, type ComponentNode } from "../react/renderer.ts";
+
+type LabelProps = Omit<APILabelComponent, "component" | "type"> & {
+  children: ReactNode;
+};
+
+export function Label({
+  label,
+  description,
+  children,
+  ...rest
+}: LabelProps): ReactElement<APILabelComponent> {
+  const props = DressedComponent(label, null as never, description, rest);
+  return createElement("dressed-node", props, children);
+}
+
+export async function parseLabel<T extends APILabelComponent>(
+  props: T,
+  children: ComponentNode[],
+): Promise<T> {
+  return {
+    ...props,
+    component: (await Promise.all(children.map(renderNode)))[0],
+  };
+}

--- a/packages/dressed-react/src/index.ts
+++ b/packages/dressed-react/src/index.ts
@@ -3,6 +3,7 @@ export { ActionRow } from "./components/action-row.ts";
 export { Button } from "./components/button.ts";
 export { Container } from "./components/container.ts";
 export { File } from "./components/file.ts";
+export { Label } from "./components/label.ts";
 export { MediaGallery, MediaGalleryItem } from "./components/media-gallery.ts";
 export { Section } from "./components/section.ts";
 export { SelectMenu, SelectMenuOption } from "./components/select-menu.ts";

--- a/packages/dressed-react/src/react/renderer.ts
+++ b/packages/dressed-react/src/react/renderer.ts
@@ -7,13 +7,14 @@ import {
   ComponentType,
 } from "discord-api-types/v10";
 import { TextDisplay } from "dressed";
+import { createTextNode } from "./text-node.ts";
 import { parseActionRow } from "../components/action-row.ts";
 import { parseContainer } from "../components/container.ts";
-import { parseTextDisplay } from "../components/text-display.ts";
-import { parseSelectMenu } from "../components/select-menu.ts";
+import { parseLabel } from "../components/label.ts";
 import { parseMediaGallery } from "../components/media-gallery.ts";
+import { parseSelectMenu } from "../components/select-menu.ts";
 import { parseSection } from "../components/section.ts";
-import { createTextNode } from "./text-node.ts";
+import { parseTextDisplay } from "../components/text-display.ts";
 
 export interface Renderer {
   nodes: Node<unknown>[];
@@ -104,6 +105,9 @@ export async function renderNode(
     }
     case ComponentType.Container: {
       return parseContainer(node.props, node.children);
+    }
+    case ComponentType.Label: {
+      return parseLabel(node.props, node.children);
     }
     default: {
       if (typeof node.props === "string") {

--- a/packages/dressed-react/src/rendering/interaction.ts
+++ b/packages/dressed-react/src/rendering/interaction.ts
@@ -5,6 +5,7 @@ import type {
 } from "dressed";
 import type { createInteraction, RawFile } from "dressed/server";
 import {
+  ApplicationCommandType,
   MessageFlags,
   type APIInteractionResponseCallbackData,
   type APIModalInteractionResponseCallbackData,
@@ -44,9 +45,7 @@ type ShowModalProps = [
   data: Omit<APIModalInteractionResponseCallbackData, "components">,
 ];
 
-type ReactivatedInteraction<
-  T extends NonNullable<ReturnType<typeof createInteraction>>,
-> = OverrideMethodParams<
+type ReactivatedInteraction<T> = OverrideMethodParams<
   T,
   {
     reply: ReplyProps;
@@ -66,8 +65,9 @@ type OverrideMethodParams<T, Overrides extends Record<string, unknown[]>> = {
     : T[K];
 };
 
-export type CommandInteraction =
-  ReactivatedInteraction<DressedCommandInteraction>;
+export type CommandInteraction<
+  T extends keyof typeof ApplicationCommandType = "ChatInput",
+> = ReactivatedInteraction<DressedCommandInteraction<T>>;
 export type MessageComponentInteraction =
   ReactivatedInteraction<DressedMessageComponentInteraction>;
 export type ModalSubmitInteraction =


### PR DESCRIPTION
You can now do this:

```ts
// src/commands/hi.ts
import type { CommandInteraction } from "@dressed/react";
import type { CommandConfig } from "dressed";

export const config: CommandConfig = {
  type: "Message",
};

export default function (interaction: CommandInteraction<"Message">) {
	return interaction.reply("Hi")
}
```