### PR TITLE
feat(call-discord): use res as cause in error object

### DIFF
--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -75,11 +75,11 @@ export async function callDiscord(
     }
 
     if (res.status === 429) {
-      const ratelimit = error as RESTRateLimit;
-      updateLimit(ratelimit.global ? "global" : endpoint, 0, Date.now() + ratelimit.retry_after * 1000);
+      const { global, retry_after } = error as RESTRateLimit;
+      updateLimit(global ? "global" : endpoint, 0, Date.now() + retry_after * 1000);
     }
 
-    throw new Error(`Failed to ${options.method} ${endpoint} (${res.status})`);
+    throw new Error(`Failed to ${options.method} ${endpoint} (${res.status})`, { cause: res });
   }
 
   headerUpdateLimit(endpoint, res, options.method);


### PR DESCRIPTION
Improves error handlability
```ts
try {
  await getChannel("123");
} catch (e) {
  if (e instanceof Error && e.cause instanceof Response) {
    switch (e.cause.status) {
      case 404:
        interaction.editReply("Unknown channel!");
    }
  }
}
```