### PR TITLE
fix(ratelimit): non-inherent bucket crossover lead to unflushed reqs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
     },
     "packages/dressed-ws": {
       "name": "@dressed/ws",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "discord-api-types": "^0.38.30",
       },

--- a/packages/dressed-ws/package.json
+++ b/packages/dressed-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dressed/ws",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Inbestigator/dressed.git",

--- a/packages/dressed/src/utils/ratelimit.ts
+++ b/packages/dressed/src/utils/ratelimit.ts
@@ -2,8 +2,8 @@ interface Bucket {
   remaining: number;
   limit: number;
   queue: (() => void)[];
+  refresh: number;
   sweeper?: NodeJS.Timeout;
-  tmp?: true;
 }
 
 const buckets = new Map<string, Bucket>();
@@ -21,13 +21,13 @@ function ensureBucket(id: string) {
   return (
     buckets.get(bucketId) ??
     // biome-ignore lint/style/noNonNullAssertion: We're setting, so it's guaranteed
-    buckets.set(bucketId, { limit: 1, remaining: 1, queue: [], tmp: true }).get(bucketId)!
+    buckets.set(bucketId, { limit: 1, remaining: 1, queue: [], refresh: -1 }).get(bucketId)!
   );
 }
 
 export function checkLimit(req: Request) {
   const bucket = ensureBucket(`${req.method}:${req.url}`);
-  if (bucket.remaining-- > 0 && bucket.tmp) return checkGlobalLimit();
+  if (bucket.remaining-- > 0 && bucket.refresh < Date.now()) return checkGlobalLimit();
   return new Promise<void>((r) => bucket.queue.push(r));
 }
 
@@ -40,10 +40,12 @@ export function updateLimit(req: Request, res: Response) {
   const scope = res.headers.get("x-ratelimit-scope");
   const id = `${req.method}:${req.url}`;
   const tmpBucket = buckets.get(id);
+  const now = Date.now();
+  const refreshAfter = (Number.isNaN(retryAfter) ? resetAfter : retryAfter) * 1000;
   buckets.delete(id);
 
   if (scope === "global" && !Number.isNaN(retryAfter)) {
-    globalReset = Date.now() + retryAfter * 1000;
+    globalReset = now + retryAfter * 1000;
     return;
   }
   if ([limit, remaining, resetAfter].some(Number.isNaN) || !bucketId) return;
@@ -67,15 +69,13 @@ export function updateLimit(req: Request, res: Response) {
     limit,
     remaining,
     queue: (bucket?.queue ?? []).concat(tmpBucket?.queue ?? []),
-    sweeper: setTimeout(
-      () => {
-        const bucket = buckets.get(bucketId);
-        if (!bucket || globalReset > Date.now()) return;
-        bucket.remaining = bucket.limit;
-        release();
-      },
-      (Number.isNaN(retryAfter) ? resetAfter : retryAfter) * 1000,
-    ),
+    refresh: now + refreshAfter,
+    sweeper: setTimeout(() => {
+      const bucket = buckets.get(bucketId);
+      if (!bucket || globalReset > Date.now()) return;
+      bucket.remaining = bucket.limit;
+      release();
+    }, refreshAfter),
   });
   if (remaining > 0) release();
 }


### PR DESCRIPTION
Handler which used to fail (in CF workers) when run multiple times, now successfully always completes.

Released in [`dressed@1.10.0-canary.10.1`](https://www.npmjs.com/package/dressed/v/1.10.0-canary.10.1)

```ts
// src/commands/test.ts
import { createMessage, type CommandInteraction } from "dressed";
 
export default async function (interaction: CommandInteraction) {
  await interaction.deferReply({ ephemeral: true })

  await createMessage(interaction.channel.id, "1")
  await createMessage(interaction.channel.id, "2")
  await createMessage(interaction.channel.id, "3")

  await interaction.editReply("test");
}
```

Before:
<img width="670" height="446" alt="image" src="https://github.com/user-attachments/assets/1169106d-e28b-44a3-a551-eacad8faaea5" />
After:
<img width="880" height="958" alt="image" src="https://github.com/user-attachments/assets/d5a1de7e-fc29-40de-a658-a1d2362fc839" />
