### PR TITLE
fix: allow disabling full URL logging in errors (#210)

### DIFF
--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -38,6 +38,12 @@ export interface CallConfig {
    */
   routeBase?: string;
   /**
+   * Whether to log the full URL/endpoint in errors.
+   * Useful for webhooks where the token is part of the URL.
+   * @default true
+   */
+  logFullUrl?: boolean;
+  /**
    * Immediately fire the request instead of checking for ratelimits, also bypasses batching.
    * @important Unless you're checking elsewhere, this *will* attract ratelimit errors
    */

--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -38,11 +38,10 @@ export interface CallConfig {
    */
   routeBase?: string;
   /**
-   * Whether to log the full URL/endpoint in errors.
-   * Useful for webhooks where the token is part of the URL.
+   * Whether to redact the token in Discord webhook URLs in errors.
    * @default true
    */
-  logFullUrl?: boolean;
+  redactWebhookURL?: boolean;
   /**
    * Immediately fire the request instead of checking for ratelimits, also bypasses batching.
    * @important Unless you're checking elsewhere, this *will* attract ratelimit errors

--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -81,13 +81,7 @@ export async function callDiscord(
       return callDiscord(endpoint, init, $req);
     }
 
-    let error: RESTError;
-    try {
-      error = await res.json();
-    } catch {
-      error = { message: res.statusText, code: 0 };
-    }
-
+    const error: RESTError = await res.json();
     logger.error(new Error(`${error.message} (${error.code ?? res.status})`, { cause: { req, res } }));
 
     if (error.errors) logErrorData(error.errors);

--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -54,7 +54,9 @@ export async function callDiscord(
   } = { ...config.requests, ...$req };
   const hooks = { ...config.hooks, ...$req.hooks };
   const url = new URL(routeBase + endpoint);
-  const safeEndpoint = redactWebhookURL ? endpoint.replace(/\/webhooks\/(\d+)\/[^/?]+/, "/webhooks/$1/[REDACTED]") : endpoint;
+  const safeEndpoint = redactWebhookURL
+    ? endpoint.replace(/\/webhooks\/(\d+)\/[^/?]+/, "/webhooks/$1/[REDACTED]")
+    : endpoint;
 
   if (params) {
     for (const [key, value] of Object.entries(params)) {
@@ -85,7 +87,7 @@ export async function callDiscord(
     } catch {
       error = { message: res.statusText, code: 0 };
     }
-    
+
     logger.error(new Error(`${error.message} (${error.code ?? res.status})`, { cause: { req, res } }));
 
     if (error.errors) logErrorData(error.errors);

--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -79,7 +79,13 @@ export async function callDiscord(
       return callDiscord(endpoint, init, $req);
     }
 
-    const error: RESTError = await res.json();
+    let error: RESTError;
+    try {
+      error = await res.json();
+    } catch {
+      error = { message: res.statusText, code: 0 };
+    }
+    
     logger.error(new Error(`${error.message} (${error.code ?? res.status})`, { cause: { req, res } }));
 
     if (error.errors) logErrorData(error.errors);

--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -48,11 +48,13 @@ export async function callDiscord(
     authorization = `Bot ${$req.env?.DISCORD_TOKEN ?? botEnv.DISCORD_TOKEN}`,
     bucketTTL = 30 * 60,
     routeBase = RouteBases.api,
+    logFullUrl = true,
     skipQueue,
     tries = 3,
   } = { ...config.requests, ...$req };
   const hooks = { ...config.hooks, ...$req.hooks };
   const url = new URL(routeBase + endpoint);
+  const safeEndpoint = logFullUrl ? endpoint : endpoint.replace(/\/webhooks\/(\d+)\/[^/?]+/, "/webhooks/$1/[REDACTED]");
 
   if (params) {
     for (const [key, value] of Object.entries(params)) {
@@ -82,7 +84,7 @@ export async function callDiscord(
 
     if (error.errors) logErrorData(error.errors);
 
-    throw new Error(`Failed to ${options.method} ${endpoint} (${res.status})`, { cause: res });
+    throw new Error(`Failed to ${options.method} ${safeEndpoint} (${res.status})`, { cause: res });
   }
 
   req = (await hooks.onBeforeFetch?.(req.clone())) ?? req;

--- a/packages/dressed/src/utils/call-discord.ts
+++ b/packages/dressed/src/utils/call-discord.ts
@@ -48,13 +48,13 @@ export async function callDiscord(
     authorization = `Bot ${$req.env?.DISCORD_TOKEN ?? botEnv.DISCORD_TOKEN}`,
     bucketTTL = 30 * 60,
     routeBase = RouteBases.api,
-    logFullUrl = true,
+    redactWebhookURL = true,
     skipQueue,
     tries = 3,
   } = { ...config.requests, ...$req };
   const hooks = { ...config.hooks, ...$req.hooks };
   const url = new URL(routeBase + endpoint);
-  const safeEndpoint = logFullUrl ? endpoint : endpoint.replace(/\/webhooks\/(\d+)\/[^/?]+/, "/webhooks/$1/[REDACTED]");
+  const safeEndpoint = redactWebhookURL ? endpoint.replace(/\/webhooks\/(\d+)\/[^/?]+/, "/webhooks/$1/[REDACTED]") : endpoint;
 
   if (params) {
     for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
This PR addresses issue #210 by allowing users to disable or redact full URL/endpoint logging when Discord API operations fail. This is particularly important for webhook URLs, where the token is part of the URL and could be exposed in logs, screenshots, or livestreams.

### Changes:
- Added `logFullUrl` (boolean) to `CallConfig` in `packages/dressed/src/types/config.ts`.
- Updated `callDiscord` in `packages/dressed/src/utils/call-discord.ts` to redact the token in webhook URLs (e.g., `/webhooks/ID/[REDACTED]`) when `logFullUrl` is set to `false`.
- Used the sanitized `safeEndpoint` in thrown Error messages.

Closes #210