### PR TITLE
refactor!: make default port 3000 (#274)

### DIFF
--- a/packages/dressed-framework/src/bin/dressed.ts
+++ b/packages/dressed-framework/src/bin/dressed.ts
@@ -16,7 +16,7 @@ program
   .option("-i, --instance", "Include code to start a server instance")
   .option("-r, --register", "Include code to register commands")
   .option("-e, --endpoint <endpoint>", "The endpoint to listen on, defaults to `/`")
-  .option("-p, --port <port>", "The port to listen on, defaults to `8000`", (v) => {
+  .option("-p, --port <port>", "The port to listen on, defaults to `3000`", (v) => {
     const parsed = Number.parseInt(v, 10);
     if (Number.isNaN(parsed) || parsed < 0 || parsed > 65_535) {
       throw new InvalidArgumentError("Port must be a valid TCP/IP network port number (0-65535)");

--- a/packages/dressed/src/server/server.ts
+++ b/packages/dressed/src/server/server.ts
@@ -27,7 +27,7 @@ export function createServer(
 ): Server {
   config = { ...dressedConfig.server, ...config };
   const hooks = { ...dressedConfig.hooks, ...config.hooks };
-  const port = config.port ?? 8000;
+  const port = config.port ?? 3000;
   const endpoint = new URL(config.endpoint ?? "/", `http://localhost:${port}`);
   const server = createHttpServer(async (req, res) => {
     if (req.url !== endpoint.pathname) {

--- a/packages/dressed/src/types/config.ts
+++ b/packages/dressed/src/types/config.ts
@@ -73,7 +73,7 @@ export interface ServerConfig {
   endpoint?: string;
   /**
    * The port to listen on.
-   * @default 8000
+   * @default 3000
    */
   port?: number;
   hooks?: {

--- a/www/content/dressed-config.md
+++ b/www/content/dressed-config.md
@@ -86,7 +86,7 @@ The endpoint to listen on, the default for this is `/`.
 
 #### Port
 
-The port to listen on, the default for this is `8000`.
+The port to listen on, the default for this is `3000`.
 
 ### Build
 


### PR DESCRIPTION
The default port previously was 8000, this was purely for backwards compatibility with the original Deno implmentation, which defaults to 8000.

Resolves #274