### PR TITLE
feat: replace commander and add flat component discovery

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,8 +22,7 @@
       "nursery": {
         "useSortedClasses": "on"
       }
-    },
-    "includes": ["!www/src/ui"]
+    }
   },
   "assist": {
     "actions": {

--- a/bun.lock
+++ b/bun.lock
@@ -16,9 +16,9 @@
       "version": "0.1.4",
       "bin": "dist/index.js",
       "dependencies": {
-        "commander": "^15.0.0",
+        "@clack/prompts": "^1.7.0",
         "dotenv": "^17.4.2",
-        "enquirer": "^2.4.1",
+        "sade": "^1.8.1",
         "tar": "^7.5.19",
       },
     },
@@ -38,9 +38,9 @@
       },
       "dependencies": {
         "@dressed/matcher": "^1.4.0",
-        "commander": "^15.0.0",
         "esbuild": "^0.28.1",
         "fast-glob": "^3.3.3",
+        "sade": "^1.8.1",
       },
       "peerDependencies": {
         "dressed": "^2.0.0-canary.1",
@@ -133,6 +133,10 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
+
+    "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
+
+    "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@dressed/framework": ["@dressed/framework@workspace:packages/dressed-framework"],
 
@@ -450,10 +454,6 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
-
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -486,8 +486,6 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
-
     "create-dressed": ["create-dressed@workspace:packages/create-dressed"],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
@@ -516,8 +514,6 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
-    "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
-
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
@@ -529,6 +525,12 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -722,6 +724,8 @@
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
@@ -794,6 +798,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -802,13 +808,13 @@
 
     "shiki": ["shiki@4.3.0", "", { "dependencies": { "@shikijs/core": "4.3.0", "@shikijs/engine-javascript": "4.3.0", "@shikijs/engine-oniguruma": "4.3.0", "@shikijs/langs": "4.3.0", "@shikijs/themes": "4.3.0", "@shikijs/types": "4.3.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A=="],
 
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
-
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "style-to-js": ["style-to-js@1.1.18", "", { "dependencies": { "style-to-object": "1.0.11" } }, "sha512-JFPn62D4kJaPTnhFUI244MThx+FEGbi+9dw1b9yBBQ+1CZpV7QAT8kUtJ7b7EUNdHajjF/0x8fT+16oLJoojLg=="],
 

--- a/packages/create-dressed/package.json
+++ b/packages/create-dressed/package.json
@@ -26,9 +26,9 @@
     "dry-publish": "bun publish --dry-run"
   },
   "dependencies": {
-    "commander": "^15.0.0",
+    "@clack/prompts": "^1.7.0",
     "dotenv": "^17.4.2",
-    "enquirer": "^2.4.1",
+    "sade": "^1.8.1",
     "tar": "^7.5.19"
   }
 }

--- a/packages/create-dressed/src/index.ts
+++ b/packages/create-dressed/src/index.ts
@@ -13,32 +13,28 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cwd, exit } from "node:process";
+import { cwd } from "node:process";
 import { pipeline } from "node:stream/promises";
-import { Command } from "commander";
+import { cancel, intro, isCancel, outro, password, select, spinner, text } from "@clack/prompts";
 import { parse } from "dotenv";
-import Enquirer from "enquirer";
+import sade from "sade";
 import { x } from "tar";
 
-const program = new Command().name("create-dressed");
-
-program
-  .description("Clone a new bot from the examples repository")
-  .argument("[name]", "Project name")
-  .argument("[template]", "Template name")
+const program = sade("create-dressed [name] [template]")
+  .describe("Clone a new bot from the examples repository")
   .action(async (name?: string, template?: string) => {
-    const { prompt } = Enquirer;
+    intro("Welcome to the Dressed project scaffolder");
 
     if (!name) {
-      name = (
-        await prompt<{ name: string }>({
-          type: "text",
-          name: "name",
-          message: "Project name:",
-          initial: "my-bot",
-          required: true,
-        }).catch(() => exit(1))
-      ).name;
+      const value = await text({
+        message: "Project name:",
+        placeholder: "my-bot",
+        validate: (value) => (!value?.length ? "Value is required!" : undefined),
+      });
+      if (isCancel(value)) {
+        return cancel("Operation cancelled.");
+      }
+      name = value;
     }
 
     const tmp = mkdtempSync(join(tmpdir(), "create-dressed-"));
@@ -46,12 +42,18 @@ program
 
     mkdirSync(tmp, { recursive: true });
 
+    const download = spinner();
+
+    download.start("Downloading templates");
+
     const res = await fetch(`https://codeload.github.com/inbestigator/dressed-examples/tar.gz/refs/heads/main`);
 
     if (!res.body || !res.ok) throw new Error("Error fetching tarball");
 
     await pipeline(res.body, createWriteStream(tarPath));
     await x({ file: tarPath, cwd: tmp, strip: 1 });
+
+    download.stop("Downloaded templates from GitHub");
 
     const nodeProjects = readdirSync(join(tmp, "node"), { withFileTypes: true })
       .filter((f) => f.isDirectory())
@@ -62,17 +64,14 @@ program
 
     if (template && !template?.includes("/")) template = `node/${template}`;
     if (!template || !(template.startsWith("deno/") ? denoProjects : nodeProjects).includes(template.slice(5))) {
-      template = `node/${
-        (
-          await prompt<{ template: string }>({
-            name: "template",
-            type: "select",
-            message: "Select the template to use",
-            choices: nodeProjects,
-            required: true,
-          }).catch(() => exit(1))
-        ).template
-      }`;
+      const value = await select({
+        message: "Select the template to use",
+        options: nodeProjects.map((p) => ({ label: p, value: `node/${p}` })),
+      });
+      if (isCancel(value)) {
+        return cancel("Operation cancelled.");
+      }
+      template = value;
     }
 
     const templateDir = join(tmp, template);
@@ -86,25 +85,22 @@ program
     }
     if (existsSync(envExamplePath)) {
       const envExample = readFileSync(envExamplePath, "utf8");
-      const envVars = await prompt(
-        Object.entries(parse(envExample)).map(([k, v]) => ({
-          type: /TOKEN|PASSWORD|KEY/.test(k) ? "password" : "text",
-          name: k,
-          message: k,
-          initial: v,
-        })),
-      ).catch(() => exit(1));
-      const envContent = Object.entries(envVars)
-        .map(([k, v]) => `${k}="${v}"`)
-        .join("\n");
+      const envVars = [];
+      for (const [k, v] of Object.entries(parse(envExample))) {
+        const value = await (/TOKEN|PASSWORD|KEY/.test(k) ? password : text)({ message: k, initialValue: v });
+        if (isCancel(value)) {
+          return cancel("Operation cancelled.");
+        }
+        envVars.push([k, value]);
+      }
+      const envContent = envVars.map(([k, v]) => `${k}="${v}"`).join("\n");
       writeFileSync(join(templateDir, ".env"), envContent);
       unlinkSync(envExamplePath);
     }
 
     cpSync(templateDir, join(cwd(), name), { recursive: true });
 
-    console.log("Project created successfully!");
-    exit();
+    outro("Project created successfully!");
   });
 
-program.parse();
+program.parse(process.argv);

--- a/packages/dressed-framework/package.json
+++ b/packages/dressed-framework/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@dressed/matcher": "^1.4.0",
-    "commander": "^15.0.0",
     "esbuild": "^0.28.1",
-    "fast-glob": "^3.3.3"
+    "fast-glob": "^3.3.3",
+    "sade": "^1.8.1"
   },
   "peerDependencies": {
     "dressed": "^2.0.0-canary.1"

--- a/packages/dressed-framework/src/bin/dressed.ts
+++ b/packages/dressed-framework/src/bin/dressed.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { rmSync, writeFileSync } from "node:fs";
-import { exit } from "node:process";
 import { logger } from "dressed/utils";
 import sade from "sade";
 import build from "../build/build.ts";
@@ -18,9 +17,15 @@ program
   .option("-e, --endpoint <endpoint>", "The endpoint to listen on", "/")
   .option("-p, --port <port>", "The port to listen on", "3000")
   .option("-I, --include <includes...>", "Glob patterns for handler files", "**/*.{js,ts,mjs}")
+  .option(
+    "--flat-components",
+    "Look for component handler files within the root. If true, [root]/buttons/hello.ts = [root]/components/buttons/hello.ts)",
+    true,
+  )
   .example("build src/bot -i")
   .example('build --include "**/*.{ts,tsx}"')
   .example("build -p 8080 -e /api/bot")
+  .example("build bot --no-flat-components")
   .action(
     async (
       root,
@@ -36,6 +41,7 @@ program
         endpoint: string;
         port: string;
         include: string | string[];
+        "flat-components": boolean;
       },
     ) => {
       const port = Number.parseInt(options.port, 10);
@@ -49,6 +55,7 @@ program
         build: {
           root,
           include: typeof include === "string" ? [include] : include,
+          flatComponents: options["flat-components"],
         },
       });
       const categories = [commands, components, events];

--- a/packages/dressed-framework/src/bin/dressed.ts
+++ b/packages/dressed-framework/src/bin/dressed.ts
@@ -19,7 +19,7 @@ program
   .option("-I, --include <includes...>", "Glob patterns for handler files", "**/*.{js,ts,mjs}")
   .option(
     "--flat-components",
-    "Look for component handler files within the root. If true, [root]/buttons/hello.ts = [root]/components/buttons/hello.ts)",
+    "Look for component handler folders within the root. If true, [root]/buttons/hello.ts = [root]/components/buttons/hello.ts",
     true,
   )
   .example("build src/bot -i")

--- a/packages/dressed-framework/src/bin/dressed.ts
+++ b/packages/dressed-framework/src/bin/dressed.ts
@@ -19,7 +19,7 @@ program
   .option("-I, --include <includes...>", "Glob patterns for handler files", "**/*.{js,ts,mjs}")
   .option(
     "--flat-components",
-    "Look for component handler folders within the root. If true, [root]/buttons/hello.ts = [root]/components/buttons/hello.ts",
+    "Look for component handler folders within the root. If true, [root]/buttons/hello.ts ≈ [root]/components/buttons/hello.ts",
     true,
   )
   .example("build src/bot -i")

--- a/packages/dressed-framework/src/bin/dressed.ts
+++ b/packages/dressed-framework/src/bin/dressed.ts
@@ -2,48 +2,54 @@
 
 import { rmSync, writeFileSync } from "node:fs";
 import { exit } from "node:process";
-import { Command, InvalidArgumentError } from "commander";
 import { logger } from "dressed/utils";
+import sade from "sade";
 import build from "../build/build.ts";
 import bundleFiles from "../build/bundle.ts";
 import { generateCategoryExports, generateFileImport, normalizeImportPath } from "../build/utils.ts";
 
-const program = new Command().name("dressed").description("A sleek, serverless-ready Discord bot framework.");
+const program = sade("dressed").describe("A sleek, serverless-ready Discord bot framework.");
 
 program
-  .command("build")
-  .description("Builds the bot and writes to .dressed")
+  .command("build [root]")
+  .describe(["Builds the bot and writes to .dressed", "[root]: Source root for the bot (default src)"])
   .option("-i, --instance", "Include code to start a server instance")
   .option("-r, --register", "Include code to register commands")
-  .option("-e, --endpoint <endpoint>", "The endpoint to listen on, defaults to `/`")
-  .option("-p, --port <port>", "The port to listen on, defaults to `3000`", (v) => {
-    const parsed = Number.parseInt(v, 10);
-    if (Number.isNaN(parsed) || parsed < 0 || parsed > 65_535) {
-      throw new InvalidArgumentError("Port must be a valid TCP/IP network port number (0-65535)");
-    }
-    return parsed;
-  })
-  .option("-R, --root <root>", "Source root for the bot, defaults to `src`")
-  .option("-I, --include <includes...>", "Glob patterns for handler files, defaults to `**/*.{js,ts,mjs}`")
+  .option("-e, --endpoint <endpoint>", "The endpoint to listen on", "/")
+  .option("-p, --port <port>", "The port to listen on", "3000")
+  .option("-I, --include <includes...>", "Glob patterns for handler files", "**/*.{js,ts,mjs}")
+  .example("build src/bot -i")
+  .example('build --include "**/*.{ts,tsx}"')
+  .example("build -p 8080 -e /api/bot")
   .action(
-    async ({
-      instance,
-      register,
-      endpoint,
-      port,
+    async (
       root,
-      include,
-    }: {
-      instance?: boolean;
-      register?: boolean;
-      endpoint?: string;
-      port?: number;
-      root?: string;
-      include?: string[];
-    }) => {
+      {
+        instance,
+        register,
+        endpoint,
+        include,
+        ...options
+      }: {
+        instance?: boolean;
+        register?: boolean;
+        endpoint: string;
+        port: string;
+        include: string | string[];
+      },
+    ) => {
+      const port = Number.parseInt(options.port, 10);
+
+      if (Number.isNaN(port) || port < 0 || port > 65_535) {
+        throw new Error("Port must be a valid TCP/IP network port number (0-65535)");
+      }
+
       const { commands, components, events, configPath } = await build({
         server: { endpoint, port },
-        build: { root, include },
+        build: {
+          root,
+          include: typeof include === "string" ? [include] : include,
+        },
       });
       const categories = [commands, components, events];
       const outputContent = `
@@ -76,8 +82,7 @@ ${instance ? "createServer(commands, components, events);" : ""}`.trim();
         instance ? `\n${instancePrefix} Starts a server instance` : "",
         register ? "\n└ Registers commands" : "",
       );
-      exit();
     },
   );
 
-program.parse();
+program.parse(process.argv);

--- a/packages/dressed-framework/src/build/build.ts
+++ b/packages/dressed-framework/src/build/build.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
-import { basename, extname, resolve } from "node:path";
+import { basename, extname, join, resolve } from "node:path";
 import { getApp } from "dressed";
 import { botEnv, config as dressedConfig, logger } from "dressed/utils";
 import type { DressedConfig } from "../types/config.ts";
@@ -37,23 +37,33 @@ export default async function build(
   }
 
   const root = config.build?.root ?? "src";
-  const categories = ["commands", "components", "events"];
+  const categories = ["commands", "components", "buttons", "modals", "selects", "events"];
   const files = await Promise.all(categories.map((d) => crawlDir(root, d, config.build?.include)));
   const entriesPath = ".dressed/tmp/entries.ts";
+  const flatComponents = files.splice(2, 3).flat();
+
+  if (config.build?.flatComponents !== false) files[1].push(...flatComponents);
 
   writeFileSync(
     entriesPath,
     [files.map((c) => c.map(generateFileImport)), generateCategoryExports(files)].flat(2).join(""),
   );
+
   logger.defer("Bundling handlers");
+
   await bundle(entriesPath, ".dressed/tmp");
+
   const { commands, components, events } = await import(resolve(entriesPath.replace(".ts", ".mjs")));
+  const componentsBase = join(root, "components");
 
   logger.raw.log(); // This just adds a newline before the logged trees for consistency
   return {
-    commands: parseCommands(commands, `${root}/commands`),
-    components: parseComponents(components, `${root}/components`),
-    events: parseEvents(events, `${root}/events`),
+    commands: parseCommands(commands, join(root, "commands")),
+    components: parseComponents(
+      components,
+      config.build?.flatComponents !== false && flatComponents.length ? [componentsBase, root] : componentsBase,
+    ),
+    events: parseEvents(events, join(root, "commands")),
     config,
     configPath,
   };

--- a/packages/dressed-framework/src/build/build.ts
+++ b/packages/dressed-framework/src/build/build.ts
@@ -37,7 +37,7 @@ export default async function build(
   }
 
   const root = config.build?.root ?? "src";
-  const categories = ["commands", "components", "buttons", "modals", "selects", "events"];
+  const categories = ["commands", "components", "buttons?", "modals?", "selects?", "events"];
   const files = await Promise.all(categories.map((d) => crawlDir(root, d, config.build?.include)));
   const entriesPath = ".dressed/tmp/entries.ts";
   const flatComponents = files.splice(2, 3).flat();

--- a/packages/dressed-framework/src/build/parsers/components.ts
+++ b/packages/dressed-framework/src/build/parsers/components.ts
@@ -1,4 +1,4 @@
-import { sep } from "node:path";
+import { relative, sep } from "node:path";
 import { patternToRegex, scorePattern } from "@dressed/matcher";
 import type { ComponentData } from "dressed/server";
 import { logger } from "dressed/utils";
@@ -8,15 +8,15 @@ export const parseComponents: ReturnType<typeof createHandlerParser<ComponentDat
   createHandlerParser({
     colNames: ["Component", "Category"],
     uniqueKeys: ["category", "regex"],
-    itemMessages({ name, path }) {
-      const category = getCategory(path);
+    itemMessages({ name, path }, base) {
+      const category = getCategory(path, base);
       return {
-        confict: `"${name}" conflicts with another ${category?.slice(0, -1)}, skipping`,
+        confict: `"${name}" conflicts with another ${category?.slice(0, -1) ?? "handler"}, skipping`,
         cols: [category ?? ""],
       };
     },
-    createData({ name, path, exports: { pattern = name } = {} }) {
-      const category = getCategory(path);
+    createData({ name, path, exports: { pattern = name } = {} }, base) {
+      const category = getCategory(path, base);
 
       if (!category) {
         throw new Error(`${logger.symbols.warn} Category for "${name}" could not be determined, skipping`, {
@@ -33,15 +33,14 @@ export const parseComponents: ReturnType<typeof createHandlerParser<ComponentDat
 
 const validComponentCategories = new Set(["buttons", "modals", "selects"]);
 
-function getCategory(path: string) {
-  const parts = path.split(sep);
+function getCategory(path: string, base: string) {
+  const relativePath = relative(base, path);
 
-  const compIndex = parts.lastIndexOf("components");
-  if (compIndex === -1) return null;
+  if (relativePath.startsWith("..")) return null;
 
-  for (let i = parts.length - 2; i > compIndex; --i) {
-    if (validComponentCategories.has(parts[i])) return parts[i] as ComponentData["data"]["category"];
-  }
+  const category = relativePath.split(sep)[0];
+
+  if (validComponentCategories.has(category)) return category as ComponentData["data"]["category"];
 
   return null;
 }

--- a/packages/dressed-framework/src/build/parsers/index.ts
+++ b/packages/dressed-framework/src/build/parsers/index.ts
@@ -16,10 +16,10 @@ type BDWithData<T> = BaseData & { data?: T };
 export function createHandlerParser<T extends BDWithData<Record<keyof T["data"], unknown> | undefined>>(options: {
   colNames: string[];
   uniqueKeys?: (keyof T["data"])[];
-  itemMessages: ((file: ImportedEntry<T>) => ParserItemMessages) | ParserItemMessages;
-  createData: (file: ImportedEntry<T>, tree: ReturnType<typeof logTree>) => T["data"];
+  itemMessages: ((file: ImportedEntry<T>, base: string) => ParserItemMessages) | ParserItemMessages;
+  createData: (file: ImportedEntry<T>, base: string, tree: ReturnType<typeof logTree>) => T["data"];
   postMortem?: (items: EntriesAnd<T>) => EntriesAnd<T>;
-}): (files: ImportedEntry<T>[], base?: string) => EntriesAnd<T> {
+}): (files: ImportedEntry<T>[], base: string | string[]) => EntriesAnd<T> {
   return (files, base) => {
     if (files.length === 0) return [];
     const tree = logTree(...options.colNames);
@@ -28,17 +28,27 @@ export function createHandlerParser<T extends BDWithData<Record<keyof T["data"],
     for (const [i, file] of Object.entries(files)) {
       let data: T["data"];
       let itemMessages = options.itemMessages;
-      if (typeof itemMessages === "function") {
-        itemMessages = itemMessages(file);
+
+      const usedBase = Array.isArray(base) ? base.find((b) => file.path.startsWith(b)) : base;
+
+      if (!usedBase) {
+        throw new TypeError(`${logger.symbols.error} Couldn't figure out where the handler comes from`, {
+          cause: "dressed-parsing",
+        });
       }
+
+      if (typeof itemMessages === "function") {
+        itemMessages = itemMessages(file, usedBase);
+      }
+
       try {
         tree.push(
           files.filter((f) => f.name === file.name).length > 1
-            ? `${file.name} \x1b[2m(${relative(base ?? "", file.path)})\x1b[22m`
+            ? `${file.name} \x1b[2m(${relative(Array.isArray(base) ? (base.at(-1) ?? "") : base, file.path)})\x1b[22m`
             : file.name,
           ...(itemMessages.cols ?? []),
         );
-        data = options.createData(file, tree);
+        data = options.createData(file, usedBase, tree);
         const hasConflict = items.some(
           (item) => options.uniqueKeys?.every((k) => data?.[k] === item.data?.[k]) ?? item.name === file.name,
         );

--- a/packages/dressed-framework/src/build/utils.ts
+++ b/packages/dressed-framework/src/build/utils.ts
@@ -29,10 +29,13 @@ export function generateCategoryExports(categories: WalkEntry[][]) {
 
 /** Recursively check for files */
 export async function crawlDir(root: string, dir: string, include = ["**/*.{js,ts,mjs}"]): Promise<WalkEntry[]> {
-  const dirPath = resolve(root, dir);
+  const optional = dir.endsWith("?");
+  const dirPath = resolve(root, optional ? dir.slice(0, -1) : dir);
 
   if (!existsSync(dirPath)) {
-    logger.warn(`${dir.slice(0, 1).toUpperCase() + dir.slice(1)} directory not found`);
+    if (!optional) {
+      logger.warn(`${dir.slice(0, 1).toUpperCase() + dir.slice(1)} directory not found`);
+    }
     return [];
   }
 

--- a/packages/dressed-framework/src/types/config.ts
+++ b/packages/dressed-framework/src/types/config.ts
@@ -6,7 +6,7 @@ export interface DressedConfig extends CoreDressedConfig {
   build?: {
     /**
      * Look for component handler folders within the root.
-     * If true, `./src/buttons/hello.ts` = `./src/components/buttons/hello.ts`
+     * If true, `./src/buttons/hello.ts` ≈ `./src/components/buttons/hello.ts`
      * @default true
      */
     flatComponents?: boolean;

--- a/packages/dressed-framework/src/types/config.ts
+++ b/packages/dressed-framework/src/types/config.ts
@@ -5,8 +5,8 @@ export interface DressedConfig extends CoreDressedConfig {
   /** Build configuration */
   build?: {
     /**
-     * Look for component handler files within the root.
-     * If true, `[root]/buttons/hello.ts` = `[root]/components/buttons/hello.ts)`
+     * Look for component handler folders within the root.
+     * If true, `./src/buttons/hello.ts` = `./src/components/buttons/hello.ts`
      * @default true
      */
     flatComponents?: boolean;

--- a/packages/dressed-framework/src/types/config.ts
+++ b/packages/dressed-framework/src/types/config.ts
@@ -5,6 +5,12 @@ export interface DressedConfig extends CoreDressedConfig {
   /** Build configuration */
   build?: {
     /**
+     * Look for component handler files within the root.
+     * If true, `[root]/buttons/hello.ts` = `[root]/components/buttons/hello.ts)`
+     * @default true
+     */
+    flatComponents?: boolean;
+    /**
      * Source root for the bot
      * @default "src"
      */

--- a/packages/dressed-framework/tests/__snapshots__/build.test.ts.snap
+++ b/packages/dressed-framework/tests/__snapshots__/build.test.ts.snap
@@ -16,6 +16,18 @@ exports[`Build bot 1`] = `
   "components": [
     {
       "data": {
+        "category": "selects",
+        "regex": "^user$",
+        "score": 1,
+      },
+      "exports": {
+        "default": [native code],
+      },
+      "name": "user",
+      "path": "tests/src/selects/user.ts",
+    },
+    {
+      "data": {
         "category": "buttons",
         "regex": "^button_(?<arg>.+?)$",
         "score": 0.4583333333333333,

--- a/packages/dressed-framework/tests/build.test.ts
+++ b/packages/dressed-framework/tests/build.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test";
 import build from "@dressed/framework/build";
 
-test("Build bot", async () => {
-  const result = await build({ build: { root: "tests/src" } });
-  expect(result).toMatchSnapshot();
+test("Build bot", () => {
+  expect(build({ build: { root: "tests/src" } })).resolves.toMatchSnapshot();
 });

--- a/packages/dressed-framework/tests/src/components/buttons/button.ts
+++ b/packages/dressed-framework/tests/src/components/buttons/button.ts
@@ -1,8 +1,9 @@
+import type { Params } from "@dressed/matcher";
 import type { MessageComponentInteraction } from "dressed";
 
 export const pattern = "button_:arg";
 
-export default async function exampleButton(interaction: MessageComponentInteraction, { arg }: { arg: string }) {
+export default async function (interaction: MessageComponentInteraction, { arg }: Params<typeof pattern>) {
   console.log(arg);
   await interaction.reply("Button clicked!");
 }

--- a/packages/dressed-framework/tests/src/events/ApplicationAuthorized.ts
+++ b/packages/dressed-framework/tests/src/events/ApplicationAuthorized.ts
@@ -1,5 +1,5 @@
 import type { Event } from "dressed";
 
-export default function applicationAuthorizedEvent(event: Event<"ApplicationAuthorized">) {
+export default function (event: Event<"ApplicationAuthorized">) {
   console.log(event.user.username, "just added me to", event.guild ? event.guild.name : "themself");
 }

--- a/packages/dressed-framework/tests/src/selects/user.ts
+++ b/packages/dressed-framework/tests/src/selects/user.ts
@@ -1,0 +1,5 @@
+import type { MessageComponentInteraction } from "dressed";
+
+export default async function (interaction: MessageComponentInteraction<"RoleSelect">) {
+  console.log(interaction.values);
+}

--- a/www/content/dressed-config.md
+++ b/www/content/dressed-config.md
@@ -92,6 +92,12 @@ The port to listen on, the default for this is `3000`.
 
 The build object is only available when using the config with the framework. The types with build included are exported from [@dressed/framework](https://npmjs.com/@dressed/framework).
 
+#### Include flat components
+
+Look for component handler folders within the root of the project (e.g. `src`, see build root).
+
+If true, `./src/buttons/hello.ts` = `./src/components/buttons/hello.ts`
+
 #### Build root
 
 This is the source root that the server uses when assembling files, the default is `src`.

--- a/www/content/dressed-config.md
+++ b/www/content/dressed-config.md
@@ -94,9 +94,7 @@ The build object is only available when using the config with the framework. The
 
 #### Include flat components
 
-Look for component handler folders within the root of the project (e.g. `src`, see build root).
-
-If true, `./src/buttons/hello.ts` = `./src/components/buttons/hello.ts`
+Look for component handler folders within the root of the project (e.g. `src`, see [build root](#build-root)). The default is `true` and as such, `./src/buttons/hello.ts` ≈ `./src/components/buttons/hello.ts`
 
 #### Build root
 

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -19,7 +19,7 @@ import routes from "../../../packages/dressed/src/resources/make/data";
 
 export default function Home() {
   return (
-    <main className="flex flex-col p-4 gap-8">
+    <main className="flex flex-col gap-8 p-4">
       <section className="mx-auto flex min-h-[calc(100vh-var(--spacing)*24)] max-w-5xl flex-col items-center justify-center gap-8 text-center">
         <div className="relative">
           <Image

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -207,7 +207,7 @@ client.once("ready", async () => {
           </CodeMD>
         </div>
       </section>
-      <section className="z-10 px-4 text-[0.5rem] text-muted-foreground">
+      <section className="z-10 -mt-4 px-4 text-[0.5rem] text-muted-foreground">
         ¹: "Every other library" refers to how <i>most</i> other libraries seem to follow the same syntax, as such
         Discord.js (the leading JavaScript library) was used to create the comparison snippets. Comparisons were created
         in good faith and may not use abolutely optimized code for either library. The name library.js was used in the

--- a/www/src/app/page.tsx
+++ b/www/src/app/page.tsx
@@ -19,8 +19,8 @@ import routes from "../../../packages/dressed/src/resources/make/data";
 
 export default function Home() {
   return (
-    <>
-      <main className="mx-auto flex min-h-screen max-w-5xl flex-col items-center justify-center gap-8 px-4 py-10 text-center">
+    <main className="flex flex-col p-4 gap-8">
+      <section className="mx-auto flex min-h-[calc(100vh-var(--spacing)*24)] max-w-5xl flex-col items-center justify-center gap-8 text-center">
         <div className="relative">
           <Image
             src="/dressed.webp"
@@ -66,8 +66,8 @@ export default function Home() {
             </Link>
           </Button>
         </div>
-      </main>
-      <section id="stats" className="-mt-12 flex flex-wrap items-center justify-center gap-4">
+      </section>
+      <section id="stats" className="flex flex-wrap items-center justify-center gap-4">
         <BundleSizes
           dressed={{ install: 3840, min: 137, minzip: 33.7, version: "2.0.0-rc.3" }}
           others={{
@@ -101,7 +101,7 @@ export default function Home() {
       </section>
       <section
         id="compare"
-        className="justify-center-safe extended-prose flex grid-cols-2 flex-col gap-2 p-4 pt-0 *:*:my-0! *:flex *:*:not-md:not-first:hidden *:flex-col *:gap-2 md:grid"
+        className="justify-center-safe extended-prose flex grid-cols-2 flex-col gap-4 **:my-0! *:flex *:*:not-md:not-first:hidden *:flex-col *:gap-2 md:grid"
       >
         <div>
           <CodeMD>
@@ -207,14 +207,14 @@ client.once("ready", async () => {
           </CodeMD>
         </div>
       </section>
-      <section className="z-10 -mt-3 px-4 text-[0.5rem] text-muted-foreground">
+      <section className="z-10 px-4 text-[0.5rem] text-muted-foreground">
         ¹: "Every other library" refers to how <i>most</i> other libraries seem to follow the same syntax, as such
         Discord.js (the leading JavaScript library) was used to create the comparison snippets. Comparisons were created
         in good faith and may not use abolutely optimized code for either library. The name library.js was used in the
         first snippet as it is the most general, discord.js is later used to show that logic may be specific to the
         discord.js library.
       </section>
-    </>
+    </main>
   );
 }
 

--- a/www/src/components/bundle-sizes.tsx
+++ b/www/src/components/bundle-sizes.tsx
@@ -33,7 +33,7 @@ export function BundleSizes<
       <DropdownMenu>
         <HoverCardTrigger asChild>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="group flex items-center justify-center gap-0 text-lg pl-0">
+            <Button variant="ghost" size="sm" className="group flex items-center justify-center gap-0 pl-0 text-lg">
               <span className="rounded-md border not-group-hover:bg-muted px-2 font-medium text-2xl transition-all group-hover:border-transparent">
                 {(100 - smaller * 100).toFixed(1)}%
               </span>

--- a/www/src/components/ui/dropdown-menu.tsx
+++ b/www/src/components/ui/dropdown-menu.tsx
@@ -29,7 +29,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
           className,
         )}
         {...props}
@@ -57,7 +57,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive!",
         className,
       )}
       {...props}
@@ -75,7 +75,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -104,7 +104,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -130,7 +130,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
+      className={cn("px-2 py-1.5 font-medium text-sm data-[inset]:pl-8", className)}
       {...props}
     />
   );
@@ -150,7 +150,7 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
+      className={cn("ml-auto text-muted-foreground text-xs tracking-widest", className)}
       {...props}
     />
   );
@@ -173,7 +173,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -192,7 +192,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in",
         className,
       )}
       {...props}

--- a/www/src/components/ui/hover-card.tsx
+++ b/www/src/components/ui/hover-card.tsx
@@ -26,7 +26,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
           className,
         )}
         {...props}

--- a/www/src/components/ui/svgs/chrome.tsx
+++ b/www/src/components/ui/svgs/chrome.tsx
@@ -1,6 +1,7 @@
 import type { SVGProps } from "react";
 
 const Chrome = (props: SVGProps<SVGSVGElement>) => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: Overrides the tooltip on the homepage
   <svg {...props} preserveAspectRatio="xMidYMid" viewBox="0 0 190.5 190.5">
     <path
       fill="#fff"

--- a/www/src/components/ui/svgs/firefox.tsx
+++ b/www/src/components/ui/svgs/firefox.tsx
@@ -1,6 +1,7 @@
 import type { SVGProps } from "react";
 
 const Firefox = (props: SVGProps<SVGSVGElement>) => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: Overrides the tooltip on the homepage
   <svg {...props} viewBox="0 0 256 265" preserveAspectRatio="xMidYMid">
     <defs>
       <radialGradient

--- a/www/src/components/ui/svgs/safari.tsx
+++ b/www/src/components/ui/svgs/safari.tsx
@@ -1,6 +1,7 @@
 import type { SVGProps } from "react";
 
 const Safari = (props: SVGProps<SVGSVGElement>) => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: Overrides the tooltip on the homepage
   <svg {...props} xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0 0 66.165833 65.803795">
     <defs>
       <linearGradient id="safari-b">


### PR DESCRIPTION
create-dressed and @dressed/framework now use [Sade](http://npmx.dev/sade)
Components handler files can now be placed within folders inside the root.

e.g. `./src/buttons/click-me.ts` vs `./src/components/buttons/click-me.ts`

This functionality is optional and can be disabled through config or the CLI options.