### PR TITLE
refactor(types)!: rename interaction types and ws events

### DIFF
--- a/packages/dressed-framework/package.json
+++ b/packages/dressed-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dressed/framework",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.2.1",
   "description": "A framework for creating Discord bots using Dressed.",
   "keywords": [
     "framework",

--- a/packages/dressed-framework/tests/src/components/buttons/button.ts
+++ b/packages/dressed-framework/tests/src/components/buttons/button.ts
@@ -1,9 +1,9 @@
 import type { Params } from "@dressed/matcher";
-import type { MessageComponentInteraction } from "dressed";
+import type { ComponentInteraction } from "dressed";
 
 export const pattern = "button_:arg";
 
-export default async function (interaction: MessageComponentInteraction, { arg }: Params<typeof pattern>) {
+export default async function (interaction: ComponentInteraction, { arg }: Params<typeof pattern>) {
   console.log(arg);
   await interaction.reply("Button clicked!");
 }

--- a/packages/dressed-framework/tests/src/selects/user.ts
+++ b/packages/dressed-framework/tests/src/selects/user.ts
@@ -1,5 +1,5 @@
-import type { MessageComponentInteraction } from "dressed";
+import type { ComponentInteraction } from "dressed";
 
-export default async function (interaction: MessageComponentInteraction<"RoleSelect">) {
+export default async function (interaction: ComponentInteraction<"RoleSelect">) {
   console.log(interaction.values);
 }

--- a/packages/dressed-react/package.json
+++ b/packages/dressed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dressed/react",
-  "version": "1.8.5-rc.2",
+  "version": "2.0.0",
   "description": "Render Dressed's components using React",
   "keywords": [
     "dressed",

--- a/packages/dressed-react/package.json
+++ b/packages/dressed-react/package.json
@@ -37,7 +37,7 @@
     "react-reconciler": "npm:@dressed/react-reconciler"
   },
   "peerDependencies": {
-    "dressed": "^2.0.0-rc.3",
+    "dressed": "^2.0.0-rc.5",
     "react": "^19.2.7"
   }
 }

--- a/packages/dressed-react/src/components/button.ts
+++ b/packages/dressed-react/src/components/button.ts
@@ -8,7 +8,7 @@ import type {
 import { Button as DressedComponent } from "dressed";
 import { createElement, type ReactElement } from "react";
 import { registerHandler } from "../rendering/callbacks.ts";
-import type { MessageComponentInteraction } from "../rendering/interaction.ts";
+import type { ComponentInteraction } from "../rendering/interaction.ts";
 
 interface ButtonWithCustomId extends Omit<APIButtonComponentWithCustomId, "type" | "style"> {
   style?: Exclude<keyof typeof ButtonStyle, "Link" | "Premium">;
@@ -19,7 +19,7 @@ interface ButtonWithOnClick extends Omit<ButtonWithCustomId, "custom_id"> {
    * Create a temporary handler callback, will not work in a serverless environment
    * @warn Callbacks are deleted after 30 minutes. If you wish to have a more permanent handler, it's strongly recommended to use the [traditional component system](https://dressed.js.org/docs/components).
    */
-  onClick: (interaction: MessageComponentInteraction<"Button">) => void;
+  onClick: (interaction: ComponentInteraction<"Button">) => void;
   /** An additional handler identity defined in the callback setup which will run if the `onClick` is no longer registered */
   fallback?: string;
 }

--- a/packages/dressed-react/src/components/select-menu.ts
+++ b/packages/dressed-react/src/components/select-menu.ts
@@ -3,7 +3,7 @@ import { SelectMenu as DressedComponent, SelectMenuOption as DressedOption } fro
 import { createElement, type PropsWithChildren, type ReactElement, type ReactNode } from "react";
 import type { Node } from "../react/node.ts";
 import { registerHandler } from "../rendering/callbacks.ts";
-import type { MessageComponentInteraction } from "../rendering/interaction.ts";
+import type { ComponentInteraction } from "../rendering/interaction.ts";
 
 type SelectType = "Channel" | "Mentionable" | "Role" | "String" | "User";
 
@@ -16,7 +16,7 @@ type SelectMenuWithOnSubmit<K extends SelectType> = Omit<SelectMenuWithCustomId<
    * Create a temporary handler callback, will not work in a serverless environment
    * @warn Callbacks are deleted after 30 minutes. If you wish to have a more permanent handler, it's strongly recommended to use the [traditional component system](https://dressed.js.org/docs/components).
    */
-  onSubmit: (interaction: MessageComponentInteraction<`${K}Select`>) => void;
+  onSubmit: (interaction: ComponentInteraction<`${K}Select`>) => void;
   /** An additional handler identity defined in the callback setup which will run if the `onSubmit` is no longer registered */
   fallback?: string;
 };

--- a/packages/dressed-react/src/rendering/callbacks.ts
+++ b/packages/dressed-react/src/rendering/callbacks.ts
@@ -1,6 +1,6 @@
-import { type MessageComponentInteraction, type ModalSubmitInteraction, patchInteraction } from "./interaction.ts";
+import { type ComponentInteraction, type ModalInteraction, patchInteraction } from "./interaction.ts";
 
-type Handler = ((i: MessageComponentInteraction) => unknown) | ((i: ModalSubmitInteraction) => unknown);
+type Handler = ((i: ComponentInteraction) => unknown) | ((i: ModalInteraction) => unknown);
 
 export const handlers = new Map<string, Handler & { $handlerCleaner?: NodeJS.Timeout }>();
 
@@ -12,10 +12,7 @@ export const pattern = "@dressed/react-handler-:handlerId{-:fallback}";
 export function createCallbackHandler<T extends Record<string, Handler> = {}>(fallbacks: T = {} as T) {
   for (const key in fallbacks) handlers.set(key, fallbacks[key]);
   return Object.assign(
-    async (
-      interaction: MessageComponentInteraction | ModalSubmitInteraction,
-      args: { handlerId: string; fallback?: string },
-    ) => {
+    async (interaction: ComponentInteraction | ModalInteraction, args: { handlerId: string; fallback?: string }) => {
       const handler = handlers.get(args.handlerId) ?? handlers.get(args.fallback ?? "default");
       // @ts-expect-error
       interaction = interaction.$patched === Symbol.for("@dressed/react") ? interaction : patchInteraction(interaction);

--- a/packages/dressed-react/src/rendering/interaction.ts
+++ b/packages/dressed-react/src/rendering/interaction.ts
@@ -2,8 +2,8 @@ import type { ApplicationCommandType } from "discord-api-types/v10";
 import {
   type CommandConfig,
   type CommandInteraction as DressedCommandInteraction,
-  type MessageComponentInteraction as DressedMessageComponentInteraction,
-  type ModalSubmitInteraction as DressedModalSubmitInteraction,
+  type ComponentInteraction as DressedComponentInteraction,
+  type ModalInteraction as DressedModalInteraction,
   editWebhookMessage,
 } from "dressed";
 import type { createInteraction } from "dressed/server";
@@ -59,8 +59,8 @@ export type MessageComponentInteraction<
     | "MentionableSelect"
     | "ChannelSelect"
     | undefined = undefined,
-> = ReactivatedInteraction<DressedMessageComponentInteraction<T>>;
-export type ModalSubmitInteraction = ReactivatedInteraction<DressedModalSubmitInteraction>;
+> = ReactivatedInteraction<DressedComponentInteraction<T>>;
+export type ModalSubmitInteraction = ReactivatedInteraction<DressedModalInteraction>;
 
 /**
  * Override interaction methods to accept React components

--- a/packages/dressed-react/src/rendering/interaction.ts
+++ b/packages/dressed-react/src/rendering/interaction.ts
@@ -50,7 +50,7 @@ type OverrideMethodParams<T, Overrides extends Record<string, unknown[]>> = {
 // I wish there's a better way to make it just automatically recognize the generic constraints from the original types
 export type CommandInteraction<T extends keyof typeof ApplicationCommandType | CommandConfig = "ChatInput"> =
   ReactivatedInteraction<DressedCommandInteraction<T>>;
-export type MessageComponentInteraction<
+export type ComponentInteraction<
   T extends
     | "Button"
     | "StringSelect"
@@ -60,7 +60,7 @@ export type MessageComponentInteraction<
     | "ChannelSelect"
     | undefined = undefined,
 > = ReactivatedInteraction<DressedComponentInteraction<T>>;
-export type ModalSubmitInteraction = ReactivatedInteraction<DressedModalInteraction>;
+export type ModalInteraction = ReactivatedInteraction<DressedModalInteraction>;
 
 /**
  * Override interaction methods to accept React components

--- a/packages/dressed-ws/package.json
+++ b/packages/dressed-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dressed/ws",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Communicate with the Discord Gateway",
   "keywords": [
     "dressed",

--- a/packages/dressed-ws/src/gateway.ts
+++ b/packages/dressed-ws/src/gateway.ts
@@ -19,26 +19,23 @@ interface ListenerConfig {
   once?: boolean;
 }
 
-type ParentMsg = {
+interface ParentMsg {
   type: "dispatch";
   t: GatewayDispatchEvents;
   shard: [number, number];
   d: GatewayDispatchPayload;
-};
+}
+
+export type Event<T extends EventKey> = (GatewayDispatchPayload extends infer U
+  ? U extends { t: infer E }
+    ? (typeof GatewayDispatchEvents)[T] extends E
+      ? U
+      : never
+    : never
+  : never)["d"];
 
 export type ConnectionActions = {
-  [K in EventKey as `on${K}`]: (
-    callback: (
-      data: (GatewayDispatchPayload extends infer U
-        ? U extends { t: infer T }
-          ? (typeof GatewayDispatchEvents)[K] extends T
-            ? U
-            : never
-          : never
-        : never)["d"],
-    ) => void,
-    config?: ListenerConfig,
-  ) => () => void;
+  [K in EventKey as `on${K}`]: (callback: (data: Event<K>) => void, config?: ListenerConfig) => () => void;
 } & {
   /**
    * Sends a gateway payload to Discord using the given opcode.

--- a/packages/dressed/src/index.ts
+++ b/packages/dressed/src/index.ts
@@ -25,6 +25,6 @@ export type {
   CommandAutocompleteInteraction,
   CommandInteraction,
   CommandOptionValue,
-  MessageComponentInteraction,
-  ModalSubmitInteraction,
+  ComponentInteraction,
+  ModalInteraction,
 } from "./types/interaction.ts";

--- a/packages/dressed/src/server/extenders/interaction.ts
+++ b/packages/dressed/src/server/extenders/interaction.ts
@@ -7,9 +7,9 @@ import {
 } from "discord-api-types/v10";
 import type {
   CommandInteraction,
+  ComponentInteraction,
   Interaction,
-  MessageComponentInteraction,
-  ModalSubmitInteraction,
+  ModalInteraction,
 } from "../../types/interaction.ts";
 import { getField } from "./fields.ts";
 import { getFocused, parseOptions } from "./options.ts";
@@ -45,7 +45,7 @@ export function createInteraction<T extends APIInteraction>(input: T): Interacti
       return { ...input, ...methods } as CommandInteraction<keyof typeof ApplicationCommandType> as Interaction<T>;
     }
     case InteractionType.MessageComponent: {
-      return { ...input, ...methods, values: parseValues(input) } as MessageComponentInteraction as Interaction<T>;
+      return { ...input, ...methods, values: parseValues(input) } as ComponentInteraction as Interaction<T>;
     }
     case InteractionType.ModalSubmit: {
       const components: ModalSubmitComponent[] = [];
@@ -63,7 +63,7 @@ export function createInteraction<T extends APIInteraction>(input: T): Interacti
         ...input,
         ...methods,
         getField: (c, r) => getField(c, r ?? false, components, input.data.resolved),
-      } as ModalSubmitInteraction as Interaction<T>;
+      } as ModalInteraction as Interaction<T>;
     }
   }
 }

--- a/packages/dressed/src/server/handlers/components.ts
+++ b/packages/dressed/src/server/handlers/components.ts
@@ -1,8 +1,8 @@
 import type { ComponentData } from "../../types/config.ts";
-import type { MessageComponentInteraction, ModalSubmitInteraction } from "../../types/interaction.ts";
+import type { ComponentInteraction, ModalInteraction } from "../../types/interaction.ts";
 import { createHandlerSetup } from "./index.ts";
 
-type Data = MessageComponentInteraction | ModalSubmitInteraction;
+type Data = ComponentInteraction | ModalInteraction;
 
 function getCategory(interaction: Data) {
   if (interaction.type === 5) return "modals";

--- a/packages/dressed/src/types/handlers.ts
+++ b/packages/dressed/src/types/handlers.ts
@@ -3,14 +3,14 @@ import type { AnyEvent } from "./event.ts";
 import type {
   CommandAutocompleteInteraction,
   CommandInteraction,
-  MessageComponentInteraction,
-  ModalSubmitInteraction,
+  ComponentInteraction,
+  ModalInteraction,
 } from "./interaction.ts";
 
 export type CommandHandler = (interaction: CommandInteraction) => Promise<void>;
 export type CommandAutocompleteHandler = (interaction: CommandAutocompleteInteraction) => Promise<void>;
 export type ComponentHandler = (
-  interaction: MessageComponentInteraction | ModalSubmitInteraction,
+  interaction: ComponentInteraction | ModalInteraction,
   args?: Record<string, string>,
 ) => Promise<void>;
 export type EventHandler = (event: AnyEvent) => Promise<void>;

--- a/packages/dressed/src/types/interaction.ts
+++ b/packages/dressed/src/types/interaction.ts
@@ -191,7 +191,7 @@ interface ResolvedSelectValues {
 /**
  * A message component interaction, includes methods for responding to the interaction.
  */
-export type MessageComponentInteraction<T extends "Button" | keyof ResolvedSelectValues | undefined = undefined> =
+export type ComponentInteraction<T extends "Button" | keyof ResolvedSelectValues | undefined = undefined> =
   APIMessageComponentInteraction &
     Omit<BaseInteractionMethods, "sendChoices"> & {
       data: { component_type: T extends string ? (typeof ComponentType)[T] : unknown };
@@ -208,7 +208,7 @@ export type MessageComponentInteraction<T extends "Button" | keyof ResolvedSelec
 /**
  * A modal submit interaction, includes methods for responding to the interaction.
  */
-export type ModalSubmitInteraction = APIModalSubmitInteraction &
+export type ModalInteraction = APIModalSubmitInteraction &
   Omit<BaseInteractionMethods, "showModal" | "sendChoices"> & {
     /**
      * Get a field from the user's submission
@@ -318,7 +318,7 @@ export type Interaction<T extends APIInteraction> = T extends APIApplicationComm
   : T extends APIApplicationCommandAutocompleteInteraction
     ? CommandAutocompleteInteraction
     : T extends APIMessageComponentInteraction
-      ? MessageComponentInteraction
+      ? ComponentInteraction
       : T extends APIModalSubmitInteraction
-        ? ModalSubmitInteraction
+        ? ModalInteraction
         : null;

--- a/www/content/guide/counter.md
+++ b/www/content/guide/counter.md
@@ -51,7 +51,7 @@ export function countDisplay(n: number) {
     TextDisplay(`Current count: ${n}`),
     ActionRow(
       Button({ label: "Add", custom_id: `set-counter-${n + 1}` }),
-      Button({ label: "Reset", style: "Danger", custom_id: "set-counter-0" })
+      Button({ label: "Reset", style: "Danger", custom_id: "set-counter-0" }),
     ),
   ];
 }
@@ -67,14 +67,14 @@ Start by creating a file within `src/components/buttons` named `set-counter.ts`.
 
 ```ts showLineNumbers
 import type { Params } from "@dressed/matcher";
-import type { MessageComponentInteraction } from "dressed";
+import type { ComponentInteraction } from "dressed";
 import { countDisplay } from "../../commands/counter.ts";
 
 export const pattern = "set-counter-:value";
 
 export default function setCounterButton(
-  interaction: MessageComponentInteraction,
-  { value }: Params<typeof pattern>
+  interaction: ComponentInteraction,
+  { value }: Params<typeof pattern>,
 ) {
   interaction.update({ components: countDisplay(Number(value)) });
 }

--- a/www/content/interactions.md
+++ b/www/content/interactions.md
@@ -130,11 +130,11 @@ interaction.sendChoices([
 
 ### values
 
-For selectmenus this is will be an array of the resolved values submitted by the user. You can choose what type it'll be by specifying the generic in `MessageComponentInteraction`.
+For selectmenus this is will be an array of the resolved values submitted by the user. You can choose what type it'll be by specifying the generic in `ComponentInteraction`.
 
 ```ts
 const users = interaction.values;
-//            ^? const interaction: MessageComponentInteraction<"UserSelect">
+//            ^? const interaction: ComponentInteraction<"UserSelect">
 ```
 
 ### update

--- a/www/content/react.md
+++ b/www/content/react.md
@@ -160,15 +160,15 @@ export { pattern } from "@dressed/react/callbacks";
 The callback handler takes an object of functions which can be used as fallbacks if the original handler is lost before the user interacts (such as if your bot restarts).
 
 ```tsx title="src / components / buttons / react.ts" showLineNumbers
-import type { MessageComponentInteraction } from "@dressed/react";
+import type { ComponentInteraction } from "@dressed/react";
 import { createCallbackHandler } from "@dressed/react/callbacks";
 
 const buttonCallbackHandler = createCallbackHandler({
   // The default fallback will be called if no fallback is specified in the component
-  default(i: MessageComponentInteraction) {
+  default(i: ComponentInteraction) {
     return i.reply("That handler has expired", { ephemeral: true });
   },
-  counter(i: MessageComponentInteraction) {
+  counter(i: ComponentInteraction) {
     return i.reply("This counter is no longer interactive!", { ephemeral: true });
   },
 });


### PR DESCRIPTION
Is this wanted? `CommandInteraction` should technically be called `ApplicationCommandInteraction`, so it's already a precedent to simplify the name